### PR TITLE
Additive-only automatic schema sync on startup

### DIFF
--- a/.agent-docs/adr/0005-additive-only-schema-sync.md
+++ b/.agent-docs/adr/0005-additive-only-schema-sync.md
@@ -10,6 +10,6 @@ This also collapses `sql_models.py` and `mariadb/init.sql` into a single source 
 
 ## Consequences
 
-- Widening an existing column's constraint (e.g. adding `NOT NULL` to a column that already has data) is permanently out of scope for the automated tool. Every future feature's schema additions must be genuinely additive (new tables/columns, nullable or defaulted) or handled by hand.
+- Widening an existing column's constraint (e.g. adding `NOT NULL` to a column that already has data) is permanently out of scope for the automated tool. Every future feature's schema additions must be genuinely additive (new tables/columns, nullable or defaulted) or handled by hand. This includes adding a brand new `NOT NULL` column with no `server_default` to a table that already has rows — MariaDB will reject the `ALTER TABLE ... ADD COLUMN` outright, which is the fail-fast behaviour working as designed, not a bug to guard against in code.
 - A schema-sync failure at startup is fatal by design (fail fast, matching the existing `get_settings` startup-failure precedent) — the app will not run against a schema it couldn't verify or extend.
 - This was verified against SQLite in tests; real MariaDB-specific DDL behavior has not been exercised in this environment (Docker Desktop unavailable here) and is worth a manual check after first deploy.

--- a/.agent-docs/adr/0005-additive-only-schema-sync.md
+++ b/.agent-docs/adr/0005-additive-only-schema-sync.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Additive-only, hand-rolled schema sync on app startup
+
+`mariadb/init.sql` only runs when MariaDB's data directory is empty, so on the Pi's already-populated volume it never re-executes — every schema change since the app first deployed has required a manual DDL step nobody remembered to do consistently. We decided to have the app synchronize its own schema automatically on every startup, rather than adopt a versioned migration framework (Alembic or similar), because this is a single-user deployment with one target and no rollback requirement — the operational weight of a full migration tool isn't earned here. The sync is restricted to additive changes only: creating missing tables (via SQLAlchemy's `metadata.create_all(engine, checkfirst=True)`) and adding missing columns to existing tables (via a small hand-rolled diff against `sqlalchemy.inspect()`). It never drops a table, drops a column, or alters an existing column's type or nullability — that class of change stays a deliberate, manual, one-off action outside the tool, because a bug in an automated destructive migration is the one failure mode that can't be undone on a database holding the only copy of collected consumption/pricing history.
+
+This also collapses `sql_models.py` and `mariadb/init.sql` into a single source of truth: `init.sql` now only creates the `octopus` database, and every table definition lives in `sql_models.py` alone. The two files drifting apart was a recurring review cost before this change.
+
+## Consequences
+
+- Widening an existing column's constraint (e.g. adding `NOT NULL` to a column that already has data) is permanently out of scope for the automated tool. Every future feature's schema additions must be genuinely additive (new tables/columns, nullable or defaulted) or handled by hand.
+- A schema-sync failure at startup is fatal by design (fail fast, matching the existing `get_settings` startup-failure precedent) — the app will not run against a schema it couldn't verify or extend.
+- This was verified against SQLite in tests; real MariaDB-specific DDL behavior has not been exercised in this environment (Docker Desktop unavailable here) and is worth a manual check after first deploy.

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -31,15 +31,15 @@ The classification of a pricing plan — `variable`, `economy7`, `agile`, `fixed
 _Avoid_: plan type, rate type
 
 **Agile**:
-Octopus's half-hourly dynamic electricity pricing tariff. Detection exists but price retrieval for it is unimplemented.
+Octopus's half-hourly dynamic electricity pricing tariff, detected via tariff code containing `AGILE`. Its rates are fetched and stored through the same generic path as every other product (see `PricingRetriever`); a dedicated Agile forecast/comparison feature is still unbuilt (see Tariff Comparison and Forecasting below).
 _Avoid_: dynamic tariff, agile octopus
 
 **Standing Charge**:
-The fixed daily charge component of a tariff. Modelled in `Price` and the `tariff` table, but not yet populated by any code path.
+The fixed daily charge component of a tariff. Modelled in `Price`/`Rate` and persisted per product/region in the `product_rate` table by `PricingRetriever`.
 _Avoid_: daily charge, base fee
 
 **Unit Rate**:
-The per-kWh price component of a tariff. Same unimplemented status as standing charge.
+The per-kWh price component of a tariff. Same storage path as standing charge.
 _Avoid_: price per unit, rate
 
 **Consumption**:
@@ -61,16 +61,12 @@ _Avoid_: customer, user
 ### Data Storage
 
 **MariaDB `octopus` database**:
-The sole active persistence store for this app, created by `mariadb/init.sql`. Holds `consumption`, `tariff`, and `cost` tables.
+The sole active persistence store for this app. The database itself is created by `mariadb/init.sql`; every table inside it is defined solely by `app/data/mysql/sql_models.py` (see **Schema Sync**) and includes `consumption`, `agreement`, `product`, `product_rate`, and `job_run`.
 _Avoid_: the database, mysql db
 
-**`tariff` table**:
-Schema for tariff price periods (standing charge, unit rate, validity dates). Exists but nothing currently writes to it.
-_Avoid_: pricing table
-
-**`cost` table**:
-Schema linking consumption to tariff for computed cost in GBP. Exists but unused so far.
-_Avoid_: billing table
+**Schema Sync**:
+The additive-only schema reconciliation `MariaDBClient` runs automatically on every app startup — creates any table missing from the live database and adds any column missing from an existing table, both diffed against `sql_models.py`. Never drops or alters an existing column; that stays a deliberate manual action. See [ADR-0005](adr/0005-additive-only-schema-sync.md).
+_Avoid_: migration, schema migration (this project deliberately has no versioned migration tool)
 
 **InfluxDB (legacy)**:
 The time-series store described in the README and implemented under `app/_deprecated/`, no longer wired into `main.py`. MariaDB is the active sink.
@@ -91,7 +87,7 @@ Orchestrates paginated consumption retrieval from Octopus and writes it to Maria
 _Avoid_: consumption service
 
 **`PricingRetriever`**:
-Placeholder class for tariff/price-history retrieval. Currently unimplemented (`pass` stubs).
+Orchestrates syncing agreements, the product catalogue, the account's own product rates, and comparison rates for every other available product, writing all of it to MariaDB via `PricingSource`.
 _Avoid_: pricing service
 
 **`MonitoringClient`**:

--- a/.agent-docs/issues/chore-additive-schema-sync.md
+++ b/.agent-docs/issues/chore-additive-schema-sync.md
@@ -1,0 +1,57 @@
+# Issues: chore-additive-schema-sync
+
+## Missing-table schema sync on startup (#389)
+
+**Blocked by**: None
+
+**User stories**: 1, 4, 5 (partial — table creation only)
+
+### What to build
+
+Expose the SQLAlchemy engine from `SessionBuilder` so `MariaDBClient` can introspect it. Wire `SQLBase.metadata.create_all(engine, checkfirst=True)` into `MariaDBClient.__init__` as its final step, so any table declared in `sql_models.py` but missing from the live database is created automatically on every app startup. No special error handling — let any failure propagate and crash startup, consistent with the existing `get_settings` failure precedent.
+
+### Acceptance criteria
+
+- [ ] `SessionBuilder.engine` is accessible to `MariaDBClient`.
+- [ ] Constructing `MariaDBClient` against a database missing a table that `sql_models.py` declares results in that table existing afterward, with the correct columns.
+- [ ] Constructing `MariaDBClient` against a database that already has all tables does not raise and is a no-op.
+- [ ] A test exercises the missing-table case via the same seam `test_mariadb_upsert.py` uses (monkeypatched in-memory SQLite engine), asserting on the resulting schema via `sqlalchemy.inspect()`.
+
+---
+
+## Missing-column schema sync on startup (#390)
+
+**Blocked by**: #389
+
+**User stories**: 2, 4, 5 (remainder — column addition)
+
+### What to build
+
+For every table already present (per #1), diff its live columns (via `sqlalchemy.inspect(engine).get_columns(...)`) against the columns declared on the corresponding model in `sql_models.py`. For any column present in the model but missing live, execute `ALTER TABLE {schema}.{table} ADD COLUMN {column_ddl}`, where `column_ddl` is generated via SQLAlchemy's `CreateColumn(column).compile(dialect=engine.dialect)` rather than a hand-rolled type mapping, so DDL generation stays dialect-correct and never drifts from the model declarations. Never drops or alters an existing column — only adds missing ones.
+
+### Acceptance criteria
+
+- [ ] Constructing `MariaDBClient` against a table that exists but is missing a column results in that column existing afterward.
+- [ ] The sync never issues a `DROP` or column-alteration statement — only `CREATE TABLE` (via #1) and `ADD COLUMN`.
+- [ ] A test mirrors the throwaway-declarative-base pattern in `test_mariadb_upsert.py`: build a stripped-down version of one real table (fewer columns) as the "before" state, construct `MariaDBClient`, and assert the omitted column now exists.
+- [ ] A test confirms the full existing schema (all tables, all columns already current) is a no-op — no exception raised.
+
+---
+
+## Collapse mariadb/init.sql to single source of truth (#391)
+
+**Blocked by**: #389, #390
+
+**User stories**: 5
+
+### What to build
+
+Remove every `CREATE TABLE` and `DROP TABLE` statement from `mariadb/init.sql`, leaving only database creation. This is safe only once the sync mechanism from #1 and #2 is in place to take over table/column creation. `sql_models.py` becomes the sole source of truth for schema, eliminating the drift between it and `init.sql`.
+
+### Acceptance criteria
+
+- [ ] `mariadb/init.sql` contains only `CREATE DATABASE IF NOT EXISTS octopus;` (no table DDL).
+- [ ] No test or code path still depends on `init.sql` for table creation.
+- [ ] `.agent-docs/context.md`'s **MariaDB `octopus` database** and **Schema Sync** entries accurately describe the collapsed responsibility (already updated in this branch's working tree — verify still accurate).
+
+---

--- a/.agent-docs/issues/chore-additive-schema-sync.md
+++ b/.agent-docs/issues/chore-additive-schema-sync.md
@@ -1,3 +1,5 @@
+> Work complete — PR ready to merge.
+
 # Issues: chore-additive-schema-sync
 
 ## Missing-table schema sync on startup (#389)
@@ -12,10 +14,10 @@ Expose the SQLAlchemy engine from `SessionBuilder` so `MariaDBClient` can intros
 
 ### Acceptance criteria
 
-- [ ] `SessionBuilder.engine` is accessible to `MariaDBClient`.
-- [ ] Constructing `MariaDBClient` against a database missing a table that `sql_models.py` declares results in that table existing afterward, with the correct columns.
-- [ ] Constructing `MariaDBClient` against a database that already has all tables does not raise and is a no-op.
-- [ ] A test exercises the missing-table case via the same seam `test_mariadb_upsert.py` uses (monkeypatched in-memory SQLite engine), asserting on the resulting schema via `sqlalchemy.inspect()`.
+- [x] `SessionBuilder.engine` is accessible to `MariaDBClient`.
+- [x] Constructing `MariaDBClient` against a database missing a table that `sql_models.py` declares results in that table existing afterward, with the correct columns.
+- [x] Constructing `MariaDBClient` against a database that already has all tables does not raise and is a no-op.
+- [x] A test exercises the missing-table case via the same seam `test_mariadb_upsert.py` uses (monkeypatched in-memory SQLite engine), asserting on the resulting schema via `sqlalchemy.inspect()`.
 
 ---
 
@@ -31,10 +33,10 @@ For every table already present (per #1), diff its live columns (via `sqlalchemy
 
 ### Acceptance criteria
 
-- [ ] Constructing `MariaDBClient` against a table that exists but is missing a column results in that column existing afterward.
-- [ ] The sync never issues a `DROP` or column-alteration statement — only `CREATE TABLE` (via #1) and `ADD COLUMN`.
-- [ ] A test mirrors the throwaway-declarative-base pattern in `test_mariadb_upsert.py`: build a stripped-down version of one real table (fewer columns) as the "before" state, construct `MariaDBClient`, and assert the omitted column now exists.
-- [ ] A test confirms the full existing schema (all tables, all columns already current) is a no-op — no exception raised.
+- [x] Constructing `MariaDBClient` against a table that exists but is missing a column results in that column existing afterward.
+- [x] The sync never issues a `DROP` or column-alteration statement — only `CREATE TABLE` (via #1) and `ADD COLUMN`.
+- [x] A test mirrors the throwaway-declarative-base pattern in `test_mariadb_upsert.py`: build a stripped-down version of one real table (fewer columns) as the "before" state, construct `MariaDBClient`, and assert the omitted column now exists.
+- [x] A test confirms the full existing schema (all tables, all columns already current) is a no-op — no exception raised.
 
 ---
 
@@ -50,8 +52,8 @@ Remove every `CREATE TABLE` and `DROP TABLE` statement from `mariadb/init.sql`, 
 
 ### Acceptance criteria
 
-- [ ] `mariadb/init.sql` contains only `CREATE DATABASE IF NOT EXISTS octopus;` (no table DDL).
-- [ ] No test or code path still depends on `init.sql` for table creation.
-- [ ] `.agent-docs/context.md`'s **MariaDB `octopus` database** and **Schema Sync** entries accurately describe the collapsed responsibility (already updated in this branch's working tree — verify still accurate).
+- [x] `mariadb/init.sql` contains only `CREATE DATABASE IF NOT EXISTS octopus;` (no table DDL).
+- [x] No test or code path still depends on `init.sql` for table creation.
+- [x] `.agent-docs/context.md`'s **MariaDB `octopus` database** and **Schema Sync** entries accurately describe the collapsed responsibility (already updated in this branch's working tree — verify still accurate).
 
 ---

--- a/.agent-docs/specs/chore-additive-schema-sync.md
+++ b/.agent-docs/specs/chore-additive-schema-sync.md
@@ -1,0 +1,47 @@
+# Additive-only automatic schema sync
+
+## Problem Statement
+
+`mariadb/init.sql` only executes when MariaDB's data directory is completely empty (Docker's `docker-entrypoint-initdb.d` behaviour). On the Pi's already-populated volume, it silently never re-runs, so every schema change since the app first deployed has required an undocumented manual DDL step nobody remembered to do consistently. This will recur for every planned future feature (tariff comparison, Agile forecast, Grafana dashboard all add their own tables).
+
+## Solution
+
+`MariaDBClient` synchronizes its own schema automatically on every app startup: it creates any table missing from the live database and adds any column missing from an existing table, both diffed against the SQLAlchemy models in `sql_models.py`. The sync is additive-only — it never drops or alters an existing table or column, since that class of change is not safely automatable against the only copy of collected consumption/pricing history. `mariadb/init.sql` shrinks to just creating the `octopus` database; `sql_models.py` becomes the single source of truth for schema, eliminating the drift between it and `init.sql` that cost review time on the prior PR.
+
+## User Stories
+
+1. As the operator, I want the app to create any table my code newly declares, so that deploying a feature with a new table doesn't require me to SSH in and run DDL by hand.
+2. As the operator, I want the app to add any column my code newly declares to an existing table, so that additive schema changes (like the recent pricing pipeline) deploy without a manual step.
+3. As the operator, I want the sync to never drop or alter existing schema, so that a bug in the sync logic can't destroy collected history — that class of change stays a deliberate, manual, one-off action outside the tool.
+4. As the operator, I want the sync to fail loudly and stop the app if it can't verify or extend the schema, so that the app never silently runs against a schema it couldn't confirm.
+5. As a developer, I want table and column definitions to live in exactly one place (`sql_models.py`), so that `init.sql` and the models can no longer drift apart.
+
+## Implementation Decisions
+
+- **`SessionBuilder`** (`app/data/mysql/client.py`) currently builds `engine` as a local variable and discards it. It exposes `self.engine` so `MariaDBClient` can reach it for introspection.
+- **`MariaDBClient.__init__`** calls a new private sync step as its last action, after `SessionBuilder` is constructed. This keeps the sync self-contained to `MariaDBClient` — `main.py`'s startup orchestration does not need to know about it.
+- **Sync mechanism**, in order:
+  1. `SQLBase.metadata.create_all(engine, checkfirst=True)` — handles "entirely missing table" for free; this is the same call the `mariadb_client` test fixture already uses.
+  2. For every table declared in `SQLBase.metadata.tables` (now guaranteed to exist), use `sqlalchemy.inspect(engine).get_columns(table.name, schema=table.schema)` to list live columns and diff against the columns the model declares. For each column present in the model but absent live, execute `ALTER TABLE {schema}.{table} ADD COLUMN {column_ddl}`.
+  3. Column DDL text is generated via SQLAlchemy's own DDL compiler — `sqlalchemy.schema.CreateColumn(column).compile(dialect=engine.dialect)` — rather than a hand-rolled type-to-SQL mapping. This keeps DDL generation dialect-correct (SQLite in tests, MariaDB in prod) and automatically stays in sync as columns are added to `sql_models.py`, avoiding a second place that could drift.
+- **Failure handling**: no special catch around the sync. Any exception (from `create_all`, `inspect`, or the `ALTER TABLE` execution) propagates out of `MariaDBClient.__init__` and crashes app startup, consistent with the existing `get_settings` startup-failure precedent in `app/main.py`.
+- **`mariadb/init.sql`**: every `CREATE TABLE` / `DROP TABLE` statement is removed, leaving only `CREATE DATABASE IF NOT EXISTS octopus;`.
+- **Constraint (non-negotiable)**: the sync never drops a table/column and never alters an existing column's type, nullability, or default. Widening an existing column's constraint (e.g. adding `NOT NULL` to a column with existing data) stays permanently out of scope for this tool.
+
+## Testing Decisions
+
+- Test seam: construct `MariaDBClient` against a monkeypatched in-memory SQLite engine (the same seam `test_mariadb_upsert.py` and the `mariadb_client` fixture in `conftest.py` already use), then assert on the resulting live schema via `sqlalchemy.inspect()`. No new seam is introduced, and no diff function is unit-tested in isolation from construction.
+- **Missing-table case**: create every table except one on the engine before constructing `MariaDBClient`; assert the omitted table exists with the correct columns afterward.
+- **Missing-column case**: mirror the throwaway-declarative-base pattern already used in `test_mariadb_upsert.py` — build a stripped-down version of one real table (a subset of its columns) as the "before" schema, construct `MariaDBClient` against it, and assert the omitted column now exists.
+- **No-op case**: schema already fully current (i.e. the existing `mariadb_client` fixture, which already runs `SQLBase.metadata.create_all` before constructing the client) — construction must not raise. This is implicitly covered by every existing test that already uses that fixture, since the sync now runs on every `MariaDBClient` construction; a dedicated test adds an explicit assertion for clarity.
+- Real MariaDB-specific DDL behaviour (schema-qualified `ALTER TABLE` syntax, exact type mapping) is not exercised in this environment (Docker Desktop unavailable in this sandbox) — flagged as a manual post-deploy sanity check, not claimed as verified.
+
+## Out of Scope
+
+- Dropping or altering existing tables/columns (type changes, nullability changes, defaults) — stays a manual, deliberate action.
+- A versioned migration framework (Alembic or similar) — rejected in ADR-0005 as unearned operational weight for a single-user, single-target deployment with no rollback requirement.
+- Any changes to `tariff_comparison_result`, `agile_forecast`, or `daily_saving` tables from the future roadmap specs — this chore only builds the mechanism those features will rely on.
+
+## Further Notes
+
+Full rationale and the decision record from the prior `/design` session is in [`.agent-docs/adr/0005-additive-only-schema-sync.md`](../adr/0005-additive-only-schema-sync.md). The domain glossary entry is `.agent-docs/context.md` under **Schema Sync** (Data Storage section), already written.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ see `.agent-docs/specs/` for the roadmap.
 - **`app/`** — polls the Octopus API on a configurable interval and writes consumption
   readings to MariaDB (`data.consumption.ConsumptionRetriever` /
   `data.mysql.client.MariaDBClient`).
-- **MariaDB** — the persistence layer (see `mariadb/init.sql` for the schema).
+- **MariaDB** — the persistence layer. Schema lives solely in `app/data/mysql/sql_models.py`;
+  `data.mysql.client.MariaDBClient` syncs it into the live database automatically on every
+  app startup (creating missing tables/columns only — see
+  `.agent-docs/adr/0005-additive-only-schema-sync.md`).
 - **Grafana** (not included in this repo) — point its MySQL data source at the MariaDB
   instance to build dashboards.
 

--- a/app/data/mysql/client.py
+++ b/app/data/mysql/client.py
@@ -9,8 +9,10 @@ from common.exceptions import MariaDBError
 from common.logging import APP_LOGGER_NAME, config
 from data.model import Consumption, as_energy_char
 from data.mysql import sql_models
+from data.mysql.sql_models import SQLBase
 from data.octopus.model import Agreement, Meter, Product, Rate
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -55,16 +57,21 @@ def _rate_scoped_id(product_code: str, region: str, valid_from: datetime) -> str
 
 class SessionBuilder:
     session: sessionmaker
+    engine: Engine
 
     def __init__(self, settings: MariaDBSettings):
         uri = f"mysql+pymysql://{settings.username}:{settings.password}@{settings.host}:{settings.port}/{settings.database}"
-        engine = create_engine(uri)
-        self.session = sessionmaker(bind=engine)
+        self.engine = create_engine(uri)
+        self.session = sessionmaker(bind=self.engine)
 
 
 class MariaDBClient:
     def __init__(self, settings: MariaDBSettings) -> None:
         self._session_builder = SessionBuilder(settings)
+        self._sync_schema()
+
+    def _sync_schema(self) -> None:
+        SQLBase.metadata.create_all(self._session_builder.engine, checkfirst=True)
 
     @contextmanager
     def session_read_scope(self) -> Generator[Session, None, None]:

--- a/app/data/mysql/client.py
+++ b/app/data/mysql/client.py
@@ -86,6 +86,9 @@ class MariaDBClient:
             )
 
         inspector = inspect(engine)
+        # MariaDB/MySQL DDL auto-commits per statement, so this transaction
+        # doesn't make the ADD COLUMN loop atomic — it's just a connection
+        # scope. Idempotent regardless: a re-run picks up anything not yet added.
         with engine.begin() as connection:
             for table in SQLBase.metadata.tables.values():
                 schema = connection.schema_for_object(table)

--- a/app/data/mysql/client.py
+++ b/app/data/mysql/client.py
@@ -11,10 +11,11 @@ from data.model import Consumption, as_energy_char
 from data.mysql import sql_models
 from data.mysql.sql_models import SQLBase
 from data.octopus.model import Agreement, Meter, Product, Rate
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.schema import CreateColumn
 
 logging.config.dictConfig(config)
 logger: Logger = getLogger(APP_LOGGER_NAME)
@@ -71,7 +72,31 @@ class MariaDBClient:
         self._sync_schema()
 
     def _sync_schema(self) -> None:
-        SQLBase.metadata.create_all(self._session_builder.engine, checkfirst=True)
+        engine = self._session_builder.engine
+        SQLBase.metadata.create_all(engine, checkfirst=True)
+
+        inspector = inspect(engine)
+        with engine.begin() as connection:
+            for table in SQLBase.metadata.tables.values():
+                schema = connection.schema_for_object(table)
+                existing_columns = {
+                    column["name"]
+                    for column in inspector.get_columns(table.name, schema=schema)
+                }
+                missing_columns = [
+                    column
+                    for column in table.columns
+                    if column.name not in existing_columns
+                ]
+                if not missing_columns:
+                    continue
+
+                qualified_name = f"{schema}.{table.name}" if schema else table.name
+                for column in missing_columns:
+                    column_ddl = CreateColumn(column).compile(dialect=engine.dialect)
+                    connection.execute(
+                        text(f"ALTER TABLE {qualified_name} ADD COLUMN {column_ddl}")
+                    )
 
     @contextmanager
     def session_read_scope(self) -> Generator[Session, None, None]:

--- a/app/data/mysql/client.py
+++ b/app/data/mysql/client.py
@@ -73,7 +73,17 @@ class MariaDBClient:
 
     def _sync_schema(self) -> None:
         engine = self._session_builder.engine
+        existing_tables = set(inspect(engine).get_table_names())
+
         SQLBase.metadata.create_all(engine, checkfirst=True)
+
+        created_tables = {
+            table.name for table in SQLBase.metadata.tables.values()
+        } - existing_tables
+        if created_tables:
+            logger.info(
+                f"Schema sync: created missing tables: {sorted(created_tables)}"
+            )
 
         inspector = inspect(engine)
         with engine.begin() as connection:
@@ -90,6 +100,11 @@ class MariaDBClient:
                 ]
                 if not missing_columns:
                     continue
+
+                logger.info(
+                    f"Schema sync: adding missing columns to {table.name}: "
+                    f"{[column.name for column in missing_columns]}"
+                )
 
                 qualified_name = f"{schema}.{table.name}" if schema else table.name
                 for column in missing_columns:

--- a/app/data/mysql/sql_models.py
+++ b/app/data/mysql/sql_models.py
@@ -8,12 +8,12 @@ class consumption(SQLBase):
     __tablename__ = "consumption"
     __table_args__ = {"schema": "octopus"}
 
-    id = Column(String, primary_key=True)
-    energy = Column(String)
+    id = Column(String(50), primary_key=True)
+    energy = Column(String(1))
     period_from = Column(DateTime, nullable=False)
     period_to = Column(DateTime, nullable=False)
     raw_value = Column(Float, nullable=False)
-    unit = Column(String)
+    unit = Column(String(5))
     est_kwh = Column(Float, nullable=False)
 
 
@@ -21,10 +21,10 @@ class agreement(SQLBase):
     __tablename__ = "agreement"
     __table_args__ = {"schema": "octopus"}
 
-    id = Column(String, primary_key=True)
-    energy = Column(String, nullable=False)
-    product_code = Column(String, nullable=False)
-    tariff_code = Column(String, nullable=False)
+    id = Column(String(50), primary_key=True)
+    energy = Column(String(1), nullable=False)
+    product_code = Column(String(50), nullable=False)
+    tariff_code = Column(String(50), nullable=False)
     valid_from = Column(DateTime, nullable=False)
     valid_to = Column(DateTime)
 
@@ -33,18 +33,18 @@ class product(SQLBase):
     __tablename__ = "product"
     __table_args__ = {"schema": "octopus"}
 
-    product_code = Column(String, primary_key=True)
-    display_name = Column(String)
-    direction = Column(String)
+    product_code = Column(String(50), primary_key=True)
+    display_name = Column(String(200))
+    direction = Column(String(10))
 
 
 class product_rate(SQLBase):
     __tablename__ = "product_rate"
     __table_args__ = {"schema": "octopus"}
 
-    id = Column(String, primary_key=True)
-    product_code = Column(String, nullable=False)
-    region = Column(String, nullable=False)
+    id = Column(String(70), primary_key=True)
+    product_code = Column(String(50), nullable=False)
+    region = Column(String(1), nullable=False)
     valid_from = Column(DateTime, nullable=False)
     valid_to = Column(DateTime)
     unit_rate = Column(Numeric(9, 6), nullable=False)

--- a/app/data/mysql/sql_models.py
+++ b/app/data/mysql/sql_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Float, Integer, Numeric, String
+from sqlalchemy import Column, DateTime, Integer, Numeric, String
 from sqlalchemy.ext.declarative import declarative_base
 
 SQLBase = declarative_base()
@@ -12,9 +12,9 @@ class consumption(SQLBase):
     energy = Column(String(1))
     period_from = Column(DateTime, nullable=False)
     period_to = Column(DateTime, nullable=False)
-    raw_value = Column(Float, nullable=False)
+    raw_value = Column(Numeric(8, 5), nullable=False)
     unit = Column(String(5))
-    est_kwh = Column(Float, nullable=False)
+    est_kwh = Column(Numeric(8, 5), nullable=False)
 
 
 class agreement(SQLBase):

--- a/app/data/mysql/sql_models.py
+++ b/app/data/mysql/sql_models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, DateTime, Integer, Numeric, String
+from sqlalchemy.dialects.mysql import DECIMAL
 from sqlalchemy.ext.declarative import declarative_base
 
 SQLBase = declarative_base()
@@ -12,9 +13,9 @@ class consumption(SQLBase):
     energy = Column(String(1))
     period_from = Column(DateTime, nullable=False)
     period_to = Column(DateTime, nullable=False)
-    raw_value = Column(Numeric(8, 5), nullable=False)
+    raw_value = Column(DECIMAL(8, 5, unsigned=True), nullable=False)
     unit = Column(String(5))
-    est_kwh = Column(Numeric(8, 5), nullable=False)
+    est_kwh = Column(DECIMAL(8, 5, unsigned=True), nullable=False)
 
 
 class agreement(SQLBase):

--- a/mariadb/init.sql
+++ b/mariadb/init.sql
@@ -1,62 +1,7 @@
 -- MariaDB init script
+--
+-- Table creation is handled by MariaDBClient's schema sync on app startup
+-- (see app/data/mysql/sql_models.py and .agent-docs/adr/0005-additive-only-schema-sync.md).
+-- This file only needs to guarantee the database itself exists.
 
 CREATE DATABASE IF NOT EXISTS octopus;
-
-USE octopus;
-
-CREATE TABLE IF NOT EXISTS consumption
-(
-    id VARCHAR(50) NOT NULL,
-    energy CHAR,
-    period_from TIMESTAMP NOT NULL,
-    period_to TIMESTAMP NOT NULL,
-    raw_value DECIMAL(8,5) UNSIGNED NOT NULL,
-    unit VARCHAR(5),
-    est_kwh DECIMAL(8,5) UNSIGNED NOT NULL,
-    PRIMARY KEY (id)
-);
-
-
-DROP TABLE IF EXISTS cost;
-DROP TABLE IF EXISTS tariff;
-
-CREATE TABLE IF NOT EXISTS agreement
-(
-    id VARCHAR(50) NOT NULL,
-    energy CHAR NOT NULL,
-    product_code VARCHAR(50) NOT NULL,
-    tariff_code VARCHAR(50) NOT NULL,
-    valid_from TIMESTAMP NOT NULL,
-    valid_to TIMESTAMP,
-    PRIMARY KEY (id)
-);
-
-CREATE TABLE IF NOT EXISTS product
-(
-    product_code VARCHAR(50) NOT NULL,
-    display_name VARCHAR(200),
-    direction VARCHAR(10),
-    PRIMARY KEY (product_code)
-);
-
-CREATE TABLE IF NOT EXISTS product_rate
-(
-    id VARCHAR(70) NOT NULL,
-    product_code VARCHAR(50) NOT NULL,
-    region CHAR NOT NULL,
-    valid_from TIMESTAMP NOT NULL,
-    valid_to TIMESTAMP,
-    unit_rate DECIMAL(9,6) NOT NULL,
-    standing_charge DECIMAL(9,6) NOT NULL,
-    PRIMARY KEY (id)
-);
-
-CREATE TABLE IF NOT EXISTS job_run
-(
-    id INT NOT NULL AUTO_INCREMENT,
-    job_name VARCHAR(100) NOT NULL,
-    status VARCHAR(20) NOT NULL,
-    ran_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    error_message VARCHAR(1000),
-    PRIMARY KEY (id)
-);

--- a/tests/test_consumption_seam.py
+++ b/tests/test_consumption_seam.py
@@ -62,7 +62,7 @@ def test_consumption_fetched_from_octopus_is_persisted_and_queryable(
 
     assert len(stored) == 1
     assert stored[0].id == "E20260101000000"
-    assert Decimal(str(stored[0].est_kwh)) == Decimal("1.234")
+    assert stored[0].est_kwh == Decimal("1.234")
 
 
 @responses.activate

--- a/tests/test_cost_via_join.py
+++ b/tests/test_cost_via_join.py
@@ -88,9 +88,9 @@ def test_electricity_cost_is_computable_via_a_simple_join(
                 energy="E",
                 period_from=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
                 period_to=datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
-                raw_value=0.5,
+                raw_value=Decimal("0.5"),
                 unit="kWh",
-                est_kwh=0.5,
+                est_kwh=Decimal("0.5"),
             )
         )
         s.add(
@@ -99,9 +99,9 @@ def test_electricity_cost_is_computable_via_a_simple_join(
                 energy="E",
                 period_from=datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
                 period_to=datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                raw_value=0.3,
+                raw_value=Decimal("0.3"),
                 unit="kWh",
-                est_kwh=0.3,
+                est_kwh=Decimal("0.3"),
             )
         )
 
@@ -142,9 +142,9 @@ def test_gas_cost_is_computable_via_a_simple_join(
                 energy="G",
                 period_from=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
                 period_to=datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
-                raw_value=10.0,
+                raw_value=Decimal("10.0"),
                 unit="kWh",
-                est_kwh=10.0,
+                est_kwh=Decimal("10.0"),
             )
         )
 

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -106,6 +106,14 @@ def test_every_declared_table_compiles_as_valid_mariadb_ddl() -> None:
         CreateTable(table).compile(dialect=mysql.dialect())
 
 
+def test_consumption_quantities_reject_negative_values_on_mariadb() -> None:
+    table = SQLBase.metadata.tables["octopus.consumption"]
+    ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+
+    assert "raw_value DECIMAL(8, 5) UNSIGNED NOT NULL" in ddl
+    assert "est_kwh DECIMAL(8, 5) UNSIGNED NOT NULL" in ddl
+
+
 def test_consumption_values_round_trip_as_decimal_without_precision_loss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -77,8 +77,13 @@ def test_a_database_with_every_table_already_present_is_left_untouched(
 
     _sync_against(engine, monkeypatch)
 
-    table_names = set(inspect(engine).get_table_names())
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
     assert table_names == {table.name for table in SQLBase.metadata.tables.values()}
+
+    for table in SQLBase.metadata.tables.values():
+        columns = {column["name"] for column in inspector.get_columns(table.name)}
+        assert columns == {column.name for column in table.columns}
 
 
 def test_a_column_missing_from_an_existing_table_is_added_on_startup(

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -3,9 +3,11 @@ from common.config import MariaDBSettings
 from data.mysql.client import MariaDBClient
 from data.mysql.sql_models import SQLBase
 from sqlalchemy import Column, DateTime, Float, String, create_engine, inspect
+from sqlalchemy.dialects import mysql
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.pool import StaticPool
+from sqlalchemy.schema import CreateTable
 
 _StrippedBase = declarative_base()
 
@@ -40,6 +42,13 @@ def _settings() -> MariaDBSettings:
     )
 
 
+def _sync_against(engine: Engine, monkeypatch: pytest.MonkeyPatch) -> MariaDBClient:
+    monkeypatch.setattr(
+        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
+    )
+    return MariaDBClient(_settings())
+
+
 def test_a_table_missing_from_the_database_is_created_on_startup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -48,11 +57,8 @@ def test_a_table_missing_from_the_database_is_created_on_startup(
         table for table in SQLBase.metadata.tables.values() if table.name != "job_run"
     ]
     SQLBase.metadata.create_all(engine, tables=tables_except_job_run)
-    monkeypatch.setattr(
-        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
-    )
 
-    MariaDBClient(_settings())
+    _sync_against(engine, monkeypatch)
 
     columns = {column["name"] for column in inspect(engine).get_columns("job_run")}
     assert columns == {"id", "job_name", "status", "ran_at", "error_message"}
@@ -63,11 +69,8 @@ def test_a_database_with_every_table_already_present_is_left_untouched(
 ) -> None:
     engine = _sqlite_engine()
     SQLBase.metadata.create_all(engine)
-    monkeypatch.setattr(
-        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
-    )
 
-    MariaDBClient(_settings())
+    _sync_against(engine, monkeypatch)
 
     table_names = set(inspect(engine).get_table_names())
     assert table_names == {table.name for table in SQLBase.metadata.tables.values()}
@@ -78,11 +81,8 @@ def test_a_column_missing_from_an_existing_table_is_added_on_startup(
 ) -> None:
     engine = _sqlite_engine()
     _StrippedBase.metadata.create_all(engine)
-    monkeypatch.setattr(
-        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
-    )
 
-    MariaDBClient(_settings())
+    _sync_against(engine, monkeypatch)
 
     columns = {column["name"] for column in inspect(engine).get_columns("consumption")}
     assert columns == {
@@ -94,3 +94,8 @@ def test_a_column_missing_from_an_existing_table_is_added_on_startup(
         "unit",
         "est_kwh",
     }
+
+
+def test_every_declared_table_compiles_as_valid_mariadb_ddl() -> None:
+    for table in SQLBase.metadata.tables.values():
+        CreateTable(table).compile(dialect=mysql.dialect())

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,11 +1,16 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
 import pytest
 from common.config import MariaDBSettings
+from data.mysql import sql_models
 from data.mysql.client import MariaDBClient
 from data.mysql.sql_models import SQLBase
 from sqlalchemy import Column, DateTime, Float, String, create_engine, inspect
 from sqlalchemy.dialects import mysql
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.schema import CreateTable
 
@@ -99,3 +104,28 @@ def test_a_column_missing_from_an_existing_table_is_added_on_startup(
 def test_every_declared_table_compiles_as_valid_mariadb_ddl() -> None:
     for table in SQLBase.metadata.tables.values():
         CreateTable(table).compile(dialect=mysql.dialect())
+
+
+def test_consumption_values_round_trip_as_decimal_without_precision_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _sqlite_engine()
+    _sync_against(engine, monkeypatch)
+
+    session = sessionmaker(bind=engine)()
+    session.add(
+        sql_models.consumption(
+            id="E20260101000000",
+            energy="E",
+            period_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            period_to=datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
+            raw_value=Decimal("0.12345"),
+            unit="kWh",
+            est_kwh=Decimal("0.12345"),
+        )
+    )
+    session.commit()
+
+    stored = session.query(sql_models.consumption).one()
+    assert stored.raw_value == Decimal("0.12345")
+    assert stored.est_kwh == Decimal("0.12345")

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,0 +1,58 @@
+import pytest
+from common.config import MariaDBSettings
+from data.mysql.client import MariaDBClient
+from data.mysql.sql_models import SQLBase
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import StaticPool
+
+
+def _sqlite_engine() -> Engine:
+    return create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    ).execution_options(schema_translate_map={"octopus": None})
+
+
+def _settings() -> MariaDBSettings:
+    return MariaDBSettings(
+        host="localhost",
+        port=3306,
+        database="octopus",
+        username="test",
+        password="test",
+    )
+
+
+def test_a_table_missing_from_the_database_is_created_on_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _sqlite_engine()
+    tables_except_job_run = [
+        table for table in SQLBase.metadata.tables.values() if table.name != "job_run"
+    ]
+    SQLBase.metadata.create_all(engine, tables=tables_except_job_run)
+    monkeypatch.setattr(
+        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
+    )
+
+    MariaDBClient(_settings())
+
+    columns = {column["name"] for column in inspect(engine).get_columns("job_run")}
+    assert columns == {"id", "job_name", "status", "ran_at", "error_message"}
+
+
+def test_a_database_with_every_table_already_present_is_left_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _sqlite_engine()
+    SQLBase.metadata.create_all(engine)
+    monkeypatch.setattr(
+        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
+    )
+
+    MariaDBClient(_settings())
+
+    table_names = set(inspect(engine).get_table_names())
+    assert table_names == {table.name for table in SQLBase.metadata.tables.values()}

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -2,9 +2,24 @@ import pytest
 from common.config import MariaDBSettings
 from data.mysql.client import MariaDBClient
 from data.mysql.sql_models import SQLBase
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import Column, DateTime, Float, String, create_engine, inspect
 from sqlalchemy.engine import Engine
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.pool import StaticPool
+
+_StrippedBase = declarative_base()
+
+
+class _StrippedConsumption(_StrippedBase):
+    __tablename__ = "consumption"
+    __table_args__ = {"schema": "octopus"}
+
+    id = Column(String, primary_key=True)
+    energy = Column(String)
+    period_from = Column(DateTime, nullable=False)
+    period_to = Column(DateTime, nullable=False)
+    raw_value = Column(Float, nullable=False)
+    est_kwh = Column(Float, nullable=False)
 
 
 def _sqlite_engine() -> Engine:
@@ -56,3 +71,26 @@ def test_a_database_with_every_table_already_present_is_left_untouched(
 
     table_names = set(inspect(engine).get_table_names())
     assert table_names == {table.name for table in SQLBase.metadata.tables.values()}
+
+
+def test_a_column_missing_from_an_existing_table_is_added_on_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _sqlite_engine()
+    _StrippedBase.metadata.create_all(engine)
+    monkeypatch.setattr(
+        "data.mysql.client.create_engine", lambda *args, **kwargs: engine
+    )
+
+    MariaDBClient(_settings())
+
+    columns = {column["name"] for column in inspect(engine).get_columns("consumption")}
+    assert columns == {
+        "id",
+        "energy",
+        "period_from",
+        "period_to",
+        "raw_value",
+        "unit",
+        "est_kwh",
+    }

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -6,7 +6,7 @@ from common.config import MariaDBSettings
 from data.mysql import sql_models
 from data.mysql.client import MariaDBClient
 from data.mysql.sql_models import SQLBase
-from sqlalchemy import Column, DateTime, Float, String, create_engine, inspect
+from sqlalchemy import Column, DateTime, Float, String, create_engine, inspect, text
 from sqlalchemy.dialects import mysql
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -137,3 +137,19 @@ def test_consumption_values_round_trip_as_decimal_without_precision_loss(
     stored = session.query(sql_models.consumption).one()
     assert stored.raw_value == Decimal("0.12345")
     assert stored.est_kwh == Decimal("0.12345")
+
+
+def test_a_column_no_longer_declared_in_the_model_is_never_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _sqlite_engine()
+    SQLBase.metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(
+            text("ALTER TABLE job_run ADD COLUMN retired_field VARCHAR(10)")
+        )
+
+    _sync_against(engine, monkeypatch)
+
+    columns = {column["name"] for column in inspect(engine).get_columns("job_run")}
+    assert "retired_field" in columns


### PR DESCRIPTION
## Summary

- `MariaDBClient` now synchronizes its own schema automatically on every app startup: creates any table missing from the live database, and adds any column missing from an existing table, both diffed against `sql_models.py`. Never drops or alters an existing table/column — that stays a deliberate, manual action.
- `mariadb/init.sql` collapses to just `CREATE DATABASE IF NOT EXISTS octopus;` — `sql_models.py` is now the single source of truth for schema, closing the drift between the two files that cost review time on the prior PR.
- Fixes real bugs surfaced by making `sql_models.py` load-bearing for DDL for the first time: unlengthed `String` columns that never compiled against real MySQL/MariaDB (previously masked by `init.sql`'s own `CREATE TABLE` statements), a `Float`/`Decimal` precision mismatch on `raw_value`/`est_kwh`, and a lost `UNSIGNED` constraint — each caught and fixed across an iterative code-review loop, with regression tests added for all three.

Closes #389, #390, #391.

Design record: `.agent-docs/adr/0005-additive-only-schema-sync.md`
Spec: `.agent-docs/specs/chore-additive-schema-sync.md`

## Test plan

- [x] `pytest` — 79 tests passing, including new coverage: missing-table sync, missing-column sync, no-op idempotency (table + column level), never-drops-undeclared-columns regression, MariaDB-DDL-compiles-for-every-table regression, UNSIGNED-constraint regression, Decimal round-trip precision.
- [x] `pre-commit run --all-files` clean (mypy, black, isort, ruff, pylint, bandit, pytest).
- [x] Four-round iterative code review (Standards + Spec axes) converged with zero blocking findings.
- [ ] Real MariaDB DDL behavior not exercised in this sandbox (no Docker Desktop available) — worth a manual sanity check after first deploy, per ADR-0005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)