### PR TITLE
Fix rate-fetch URL-encoding crash and make failures non-fatal

### DIFF
--- a/.agent-docs/issues/bugfix-rate-fetch-url-encoding.md
+++ b/.agent-docs/issues/bugfix-rate-fetch-url-encoding.md
@@ -1,5 +1,7 @@
 # Issues: bugfix-rate-fetch-url-encoding
 
+> Work complete — PR ready to merge.
+
 ## Fix URL-encoding bug in rate-fetch requests (#395)
 
 **Blocked by**: None

--- a/.agent-docs/issues/bugfix-rate-fetch-url-encoding.md
+++ b/.agent-docs/issues/bugfix-rate-fetch-url-encoding.md
@@ -1,0 +1,95 @@
+# Issues: bugfix-rate-fetch-url-encoding
+
+## Fix URL-encoding bug in rate-fetch requests (#395)
+
+**Blocked by**: None
+
+**User stories**: 2
+
+### What to build
+
+`RateClient._build_endpoint` (`app/data/octopus/rate.py`) currently builds
+Octopus API request URLs for rate data by raw string concatenation, appending
+`period_from`/`period_to` as `datetime.isoformat()` directly into the query
+string. Its only encoding attempt, `.replace('+00:00', 'Z')`, special-cases
+exact UTC — any other timezone offset (e.g. British Summer Time, `+01:00`)
+leaves a literal `+` in the query string, which Octopus's API server parses as
+a space, rejecting the request with a 400 error.
+
+Per [Guy Lipman's Octopus API guide](https://www.guylipman.com/octopus/api_guide.html)
+(a well-known community reference documenting request-format behavior the
+official docs don't cover), the recommended fix is not merely to URL-encode
+the `+` correctly — the guide explicitly recommends **always converting to
+UTC and using the `Z` suffix** for `period_from`/`period_to`, warning that a
+local timezone offset (even correctly encoded) can cause inconsistent
+behavior around DST transitions. So: normalize any timezone-aware
+`period_from`/`period_to` to UTC (`.astimezone(timezone.utc)`) before
+formatting, so a raw non-`Z` offset is never sent at all, and pass the
+result via a `params` dict to `OctopusTransport.get()` (which already accepts
+one) for the first request to each endpoint. Pagination's `next` field is
+already a fully-formed absolute URL, so subsequent-page requests pass no
+additional params.
+
+### Acceptance criteria
+
+- [ ] `RateClient` no longer builds any part of the query string via raw
+      string concatenation.
+- [ ] Any timezone-aware `period_from`/`period_to` is normalized to UTC with
+      a `Z` suffix before being sent — never a raw non-`Z` offset, matching
+      Guy Lipman's guide's documented recommendation.
+- [ ] A regression test in `tests/test_electricity_rate_seam.py` fetches
+      rates using a non-UTC (`+01:00`) `period_from`/`period_to` and asserts
+      the actual outgoing request URL sends the UTC/`Z`-normalized value, and
+      that rates still parse correctly.
+- [ ] All existing tests in `test_electricity_rate_seam.py`,
+      `test_gas_rate_seam.py`, and `test_pricing_retrieval.py` still pass
+      unchanged.
+
+---
+
+## Make rate-fetch failures non-fatal to the whole app (#396)
+
+**Blocked by**: None
+
+**User stories**: 1, 3
+
+### What to build
+
+A rate-fetch failure (for any reason) currently crashes the entire app: the
+per-agreement and per-product loops in `PricingRetriever`
+(`app/data/pricing.py`) propagate any exception all the way up, and
+`main.py`'s startup call to `pricing.refresh()` has no exception handling at
+all — unlike the *scheduled* recurring pricing job, which already goes
+through `_schedule_refresh_job`'s try/except. Wrap the per-(meter, agreement)
+loop body in `_sync_own_product_rates` and the per-product loop body in
+`_sync_comparison_rates` in try/except `Exception`, logging a warning naming
+the product/tariff code and continuing to the next item on failure — same
+treatment for both loops, no distinction between the account's own agreement
+and a comparison product. Separately, extract `main.py`'s startup
+`pricing.refresh()` call into a small named function (mirroring the existing
+`startup()` helper), wrapped in try/except with `logger.exception(...)`, so a
+startup pricing failure no longer blocks `register_jobs`/
+`register_pricing_job` and the app entering its polling loop.
+
+Note: the companion issue (#395) fixes the specific root-cause bug (unencoded
+timezone offsets, per
+[Guy Lipman's Octopus API guide](https://www.guylipman.com/octopus/api_guide.html))
+that triggered this in production. This issue is independent defense-in-depth
+so *any* future rate-fetch failure — not just this one — can't take the whole
+app down.
+
+### Acceptance criteria
+
+- [ ] `_sync_own_product_rates`: a rate-fetch failure for one agreement is
+      logged and skipped; other agreements still sync. Test with two
+      agreements, one failing.
+- [ ] `_sync_comparison_rates`: a rate-fetch failure for one product is
+      logged and skipped; other products still sync. Test with two products,
+      one failing.
+- [ ] `main.py` has a named, independently-testable function wrapping the
+      startup pricing sync; a test asserts it does not propagate when
+      `PricingRetriever.refresh()` raises.
+- [ ] All existing tests in `test_pricing_retrieval.py` and
+      `test_refresh_scheduling.py` still pass unchanged.
+
+---

--- a/.agent-docs/specs/bugfix-rate-fetch-url-encoding.md
+++ b/.agent-docs/specs/bugfix-rate-fetch-url-encoding.md
@@ -1,0 +1,157 @@
+# Fix URL-encoding bug in rate fetching and make rate-fetch failures non-fatal
+
+## Problem Statement
+
+During the app's first real deployment (Raspberry Pi), it crash-looped
+indefinitely: every restart re-ran the full historical consumption backfill,
+then crashed again fetching pricing/rate data, forever. The app never reached
+its steady-state polling loop and never populated pricing data (`agreement`,
+`product`, `product_rate` tables).
+
+Root cause: `RateClient._build_endpoint` (`app/data/octopus/rate.py`) builds
+Octopus API request URLs for rate data by raw string concatenation, appending
+`period_from`/`period_to` as `datetime.isoformat()` directly into the query
+string. Its only encoding attempt, `.replace('+00:00', 'Z')`, special-cases
+exact UTC — any other timezone offset (e.g. British Summer Time, `+01:00`,
+which is in effect right now) leaves a literal `+` in the query string. Since
+`+` means "encoded space" in a URL query string, Octopus's API server parses
+`period_to=2024-05-24T00:00:00+01:00` as
+`period_to=2024-05-24T00:00:00 01:00` and rejects it with
+`{'period_to': ['Enter a valid date/time.']}` (HTTP 400).
+
+Separately, this single failure was fatal to the entire process: the
+exception propagates uncaught through `PricingRetriever.refresh()`, and
+`main.py`'s startup call to `pricing.refresh()` has no exception handling at
+all (unlike the *scheduled* recurring pricing job, which already goes through
+`_schedule_refresh_job`'s try/except and the top-level `run_pending_safely`
+catch-all). One bad rate lookup — for any reason, not just this encoding bug —
+therefore kills the whole app before consumption polling is even registered,
+and `docker-compose.yml`'s `restart: unless-stopped` just repeats the same
+failure forever.
+
+## Solution
+
+Two independent fixes, found and scoped together in one session:
+
+1. Stop building rate-fetch query strings by hand — use `requests`' `params`
+   dict (already supported by `OctopusTransport.get()`) so URL-encoding is
+   handled correctly regardless of timezone offset.
+2. Make rate-fetch failures non-fatal at every level they can occur: a failed
+   lookup for one agreement or one comparison product is logged and skipped,
+   not fatal to the others; and the startup pricing sync no longer blocks
+   consumption polling from starting if it fails for any reason.
+
+## User Stories
+
+1. As the operator of this app, I want a single rate lookup failure (for any
+   reason — a transient Octopus API issue, a malformed query, anything) to be
+   logged and skipped, so that one bad product or one bad agreement doesn't
+   take down consumption polling for everything else.
+2. As the operator of this app, I want rate requests to be correctly
+   URL-encoded regardless of the current timezone offset, so that pricing
+   sync doesn't systematically fail for roughly half the year (British Summer
+   Time).
+3. As the operator of this app, I want the app to still start up and begin
+   polling consumption even if the initial pricing sync fails entirely, so
+   that a pricing-side problem never prevents the core consumption-monitoring
+   function of the app from running.
+
+## Implementation Decisions
+
+- **`app/data/octopus/rate.py`** (`RateClient`): `_build_endpoint` is replaced
+  by building a `params: Dict[str, Any]` dict (`page_size`, and `period_from`/
+  `period_to` only if provided) passed to `OctopusTransport.get()`, instead of
+  concatenating them into the URL string, so `requests` handles encoding.
+  Per [Guy Lipman's Octopus API guide](https://www.guylipman.com/octopus/api_guide.html)
+  (a well-known community reference documenting request-format behavior the
+  official docs don't cover), the guide explicitly recommends **always
+  converting to UTC and using the `Z` suffix** for `period_from`/`period_to`
+  — it warns that supplying a local timezone offset (even one that's
+  correctly encoded) can cause inconsistent behavior around DST transitions,
+  since the consumption/price endpoints match ranges slightly differently
+  (`valid_to >= period_from` and `valid_from < period_to` for price data).
+  So the fix is not merely "URL-encode the `+` correctly" but **normalize any
+  timezone-aware `period_from`/`period_to` to UTC (`.astimezone(timezone.utc)`)
+  before formatting**, so a raw non-`Z` offset is never sent at all — this
+  is a more robust fix than encoding alone, and matches the API's own
+  documented recommendation. `_get_all_readings`/
+  `_get_readings_directly_from_endpoint` pass this `params` dict to
+  `OctopusTransport.get()` only for the *first* request to an endpoint;
+  Octopus's paginated `next` field returns an already fully-formed absolute
+  URL for subsequent pages, so those requests pass no additional params.
+- **`app/data/pricing.py`** (`PricingRetriever`):
+  - `_sync_own_product_rates`: the per-(meter, agreement) loop body (fetch
+    rates + persist) is wrapped in try/except `Exception`. On failure, log a
+    warning naming the product code and tariff code, and `continue` to the
+    next agreement rather than propagating.
+  - `_sync_comparison_rates`: the per-product loop body (tariff-code lookup +
+    rate fetch + persist) is wrapped the same way — log a warning naming the
+    product code, `continue` to the next product.
+  - Both loops get the same treatment (no distinction between the account's
+    own agreement and a comparison product) — a confirmed decision from this
+    session's design discussion.
+- **`app/main.py`**: the startup call `pricing.refresh()` (currently
+  unprotected, unlike the scheduled recurring pricing job which already goes
+  through `_schedule_refresh_job`'s try/except) is extracted into a small
+  named function, e.g. `run_initial_pricing_sync(pricing: PricingRetriever) ->
+  None`, mirroring the existing `startup()` helper's shape for testability.
+  It wraps the call in try/except `Exception`, logging via
+  `logger.exception(...)`, so a startup pricing failure no longer prevents
+  `register_jobs`/`register_pricing_job` from running and the app from
+  entering its polling loop.
+- No ADR — this is a bugfix following an established existing pattern (the
+  scheduled job's `_schedule_refresh_job` already does try/except-and-log for
+  the recurring case), not a new architectural decision.
+
+## Testing Decisions
+
+- **`tests/test_electricity_rate_seam.py`** (existing seam: mocks HTTP via
+  `responses` against `OctopusEnergyAPIClient.get_electricity_rates`, the
+  highest available seam — already used by 3 existing tests in this file):
+  add a regression test that fetches rates with a non-UTC (`+01:00`, British
+  Summer Time) `period_from`/`period_to`, and asserts on the actual outgoing
+  request URL (`responses.calls[...].request.url`) that the sent
+  `period_from`/`period_to` values are normalized to UTC with a `Z` suffix
+  (matching Guy Lipman's guide's documented recommendation) — no raw
+  non-`Z` offset appears at all, encoded or otherwise. This locks in both the
+  exact bug reproduced live in production and the documented-correct request
+  format. Also assert the rates still parse correctly.
+- **`tests/test_pricing_retrieval.py`** (existing seam: `PricingRetriever`
+  against a real `MariaDBClient` with HTTP mocked via `responses`, following
+  the existing `test_refresh_skips_a_product_with_no_published_rate_for_the_
+  region_without_crashing` pattern already in this file): add a test where
+  one product's rate-fetch endpoint returns an error response and another
+  product's succeeds — assert the failing product is skipped (no row
+  persisted for it) while the succeeding product's rate is still persisted.
+  Mirror this for the account's-own-agreement path in
+  `_sync_own_product_rates` with two agreements, one failing.
+- **`tests/test_refresh_scheduling.py`** (existing seam: tests `main.py`'s
+  `register_jobs`/`register_pricing_job`/`run_pending_safely` functions
+  directly against a `Mock(spec=...)` retriever): add a test for the new
+  `run_initial_pricing_sync` function — given a `PricingRetriever` whose
+  `refresh()` raises, assert it does not propagate.
+- No test doubles beyond what's already used in these files (`responses` for
+  HTTP, a real `mariadb_client` fixture, `Mock(spec=...)` for retrievers) —
+  mocking only at the actual system boundary (Octopus's HTTP API), per this
+  repo's existing pattern.
+
+## Out of Scope
+
+- Any change to the retry behaviour in `common/decorator.py`'s `@retry()` — a
+  systematic 400 error currently gets retried a few times before failing,
+  which is wasteful but not part of this fix's scope.
+- Any change to how `run_pending_safely` handles *scheduled* job failures —
+  that path already correctly catches and logs (confirmed by existing tests
+  in `test_refresh_scheduling.py`); only the *unprotected startup* call is
+  being fixed.
+- Any broader review of exception handling elsewhere in the app (e.g.
+  consumption polling's own resilience) — scoped strictly to the pricing/rate
+  path that actually broke in production.
+
+## Further Notes
+
+Found and reproduced live during the first real Pi deployment of
+`octopus-monitoring`, immediately after the `chore/consolidate-mariadb-env-config`
+chore (PR #394) merged — that chore's config changes are unrelated to and
+unaffected by this bug. The Pi deployment test is paused pending this fix, to
+be resumed once merged.

--- a/app/data/octopus/rate.py
+++ b/app/data/octopus/rate.py
@@ -111,6 +111,10 @@ class RateClient:
 
     @staticmethod
     def _to_utc_z(value: datetime) -> str:
+        # value is always tz-aware here (Agreement.valid_from/valid_to come from
+        # datetime.fromisoformat() of Octopus-supplied offset strings) — a naive
+        # datetime would silently pick up the system's local tz via astimezone(),
+        # reintroducing the exact offset bug this normalization exists to fix.
         return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
     def _build_params(

--- a/app/data/octopus/rate.py
+++ b/app/data/octopus/rate.py
@@ -1,8 +1,8 @@
 import logging.config
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from logging import Logger, getLogger
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from common.logging import APP_LOGGER_NAME, config
 from data.model import Energy
@@ -99,36 +99,40 @@ class RateClient:
         description: str,
     ) -> List[RateReading]:
         readings: List[RateReading] = []
-        endpoint: Optional[str] = self._build_endpoint(
-            api_endpoint, period_from, period_to
-        )
+        params: Optional[Dict[str, Any]] = self._build_params(period_from, period_to)
+        endpoint: Optional[str] = api_endpoint
         while endpoint:
             (endpoint, page) = self._get_readings_directly_from_endpoint(
-                endpoint, description
+                endpoint, params, description
             )
             readings.extend(page)
+            params = None
         return readings
 
-    def _build_endpoint(
+    @staticmethod
+    def _to_utc_z(value: datetime) -> str:
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _build_params(
         self,
-        api_endpoint: str,
         period_from: Optional[datetime],
         period_to: Optional[datetime],
-    ) -> str:
-        api_endpoint += f"?page_size={DEFAULT_PAGE_SIZE}"
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"page_size": DEFAULT_PAGE_SIZE}
         if period_from:
-            api_endpoint += (
-                f"&period_from={period_from.isoformat().replace('+00:00', 'Z')}"
-            )
+            params["period_from"] = self._to_utc_z(period_from)
         if period_to:
-            api_endpoint += f"&period_to={period_to.isoformat().replace('+00:00', 'Z')}"
-        return api_endpoint
+            params["period_to"] = self._to_utc_z(period_to)
+        return params
 
     def _get_readings_directly_from_endpoint(
-        self, api_endpoint: str, description: str
+        self,
+        api_endpoint: str,
+        params: Optional[Dict[str, Any]],
+        description: str,
     ) -> Tuple[Optional[str], List[RateReading]]:
         parsed = self._transport.get(
-            api_endpoint, RateResponse, description=description
+            api_endpoint, RateResponse, params=params, description=description
         )
         return (parsed.next, parsed.results)
 

--- a/app/data/octopus/rate.py
+++ b/app/data/octopus/rate.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from logging import Logger, getLogger
 from typing import Any, Dict, List, Optional, Tuple
 
+from common.exceptions import ArgumentError
 from common.logging import APP_LOGGER_NAME, config
 from data.model import Energy
 from data.octopus.model import Rate
@@ -111,10 +112,14 @@ class RateClient:
 
     @staticmethod
     def _to_utc_z(value: datetime) -> str:
-        # value is always tz-aware here (Agreement.valid_from/valid_to come from
-        # datetime.fromisoformat() of Octopus-supplied offset strings) — a naive
-        # datetime would silently pick up the system's local tz via astimezone(),
-        # reintroducing the exact offset bug this normalization exists to fix.
+        if value.tzinfo is None:
+            # A naive datetime would silently pick up the system's local tz via
+            # astimezone(), reintroducing the exact offset bug this
+            # normalization exists to fix — fail fast instead.
+            raise ArgumentError(
+                f"period_from/period_to must be timezone-aware, got naive "
+                f"datetime {value!r}."
+            )
         return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
     def _build_params(

--- a/app/data/pricing.py
+++ b/app/data/pricing.py
@@ -89,15 +89,22 @@ class PricingRetriever:
                 if meter.energy == Energy.electricity
                 else self._client.fetch_gas_rates
             )
-            rates = fetch_rates(
-                agreement.product_code,
-                agreement.tariff_code,
-                agreement.valid_from,
-                agreement.valid_to,
-            )
-            self._client.persist_rate(
-                agreement.product_code, self._client.region_code, rates
-            )
+            try:
+                rates = fetch_rates(
+                    agreement.product_code,
+                    agreement.tariff_code,
+                    agreement.valid_from,
+                    agreement.valid_to,
+                )
+                self._client.persist_rate(
+                    agreement.product_code, self._client.region_code, rates
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to sync rates for own agreement "
+                    f"{agreement.product_code}/{agreement.tariff_code} — "
+                    f"skipping: {e}"
+                )
 
     def _sync_comparison_rates(self, products: List[Product]) -> None:
         own_product_codes = {
@@ -122,9 +129,15 @@ class PricingRetriever:
                     f"in region {self._client.region_code} — skipping."
                 )
                 continue
-            rates = self._client.fetch_electricity_rates(
-                product.product_code, tariff_code, None, None
-            )
-            self._client.persist_rate(
-                product.product_code, self._client.region_code, rates
-            )
+            try:
+                rates = self._client.fetch_electricity_rates(
+                    product.product_code, tariff_code, None, None
+                )
+                self._client.persist_rate(
+                    product.product_code, self._client.region_code, rates
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to sync comparison rates for "
+                    f"{product.product_code}/{tariff_code} — skipping: {e}"
+                )

--- a/app/data/pricing.py
+++ b/app/data/pricing.py
@@ -99,11 +99,11 @@ class PricingRetriever:
                 self._client.persist_rate(
                     agreement.product_code, self._client.region_code, rates
                 )
-            except Exception as e:
+            except Exception:
                 logger.warning(
                     f"Failed to sync rates for own agreement "
-                    f"{agreement.product_code}/{agreement.tariff_code} — "
-                    f"skipping: {e}"
+                    f"{agreement.product_code}/{agreement.tariff_code} — skipping.",
+                    exc_info=True,
                 )
 
     def _sync_comparison_rates(self, products: List[Product]) -> None:
@@ -136,8 +136,9 @@ class PricingRetriever:
                 self._client.persist_rate(
                     product.product_code, self._client.region_code, rates
                 )
-            except Exception as e:
+            except Exception:
                 logger.warning(
                     f"Failed to sync comparison rates for "
-                    f"{product.product_code}/{tariff_code} — skipping: {e}"
+                    f"{product.product_code}/{tariff_code} — skipping.",
+                    exc_info=True,
                 )

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,13 @@ def startup(
     consumption.retrieve(period_from=limit_dt)
 
 
+def run_initial_pricing_sync(pricing: PricingRetriever) -> None:
+    try:
+        pricing.refresh()
+    except Exception:
+        logger.exception("Pricing sync failed at startup; continuing.")
+
+
 def _schedule_refresh_job(
     scheduler: Scheduler,
     refresh_config: RefreshSettings,
@@ -102,7 +109,7 @@ def main() -> None:
     pricing = PricingRetriever(client)
 
     startup(consumption, refresh_config)
-    pricing.refresh()
+    run_initial_pricing_sync(pricing)
     register_jobs(default_scheduler, refresh_config, consumption, client.mariadb)
     register_pricing_job(default_scheduler, refresh_config, pricing, client.mariadb)
 

--- a/tests/test_electricity_rate_seam.py
+++ b/tests/test_electricity_rate_seam.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
@@ -214,11 +215,15 @@ def test_a_non_utc_period_is_normalized_to_utc_z_format_in_the_request() -> None
         PRODUCT_CODE, TARIFF_CODE, period_from=period_from, period_to=period_to
     )
 
-    request_url = responses.calls[0].request.url
-    assert request_url is not None
-    assert "period_from=2024-01-05T23%3A00%3A00Z" in request_url
-    assert "period_to=2024-05-23T23%3A00%3A00Z" in request_url
-    assert "+" not in request_url
+    unit_rates_calls = [
+        call
+        for call in responses.calls
+        if call.request.url and call.request.url.startswith(UNIT_RATES_ENDPOINT)
+    ]
+    assert len(unit_rates_calls) == 1
+    query = parse_qs(urlparse(unit_rates_calls[0].request.url).query)
+    assert query["period_from"] == ["2024-01-05T23:00:00Z"]
+    assert query["period_to"] == ["2024-05-23T23:00:00Z"]
     assert len(rates) == 1
     assert rates[0].unit_rate == Decimal("24.53")
     assert rates[0].standing_charge == Decimal("48.20")

--- a/tests/test_electricity_rate_seam.py
+++ b/tests/test_electricity_rate_seam.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+import pytest
 import responses
 from common.config import OctopusAPISettings
+from common.exceptions import ArgumentError
 from data.octopus.api import OctopusEnergyAPIClient
 
 PRODUCT_CODE = "AGILE-24-10-01"
@@ -220,3 +222,12 @@ def test_a_non_utc_period_is_normalized_to_utc_z_format_in_the_request() -> None
     assert len(rates) == 1
     assert rates[0].unit_rate == Decimal("24.53")
     assert rates[0].standing_charge == Decimal("48.20")
+
+
+def test_a_naive_period_is_rejected_rather_than_silently_using_local_time() -> None:
+    naive_period_from = datetime(2024, 1, 6, 0, 0, 0)
+
+    with pytest.raises(ArgumentError, match="timezone-aware"):
+        _octopus().get_electricity_rates(
+            PRODUCT_CODE, TARIFF_CODE, period_from=naive_period_from
+        )

--- a/tests/test_electricity_rate_seam.py
+++ b/tests/test_electricity_rate_seam.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import responses
@@ -170,3 +170,32 @@ def test_paginated_unit_rates_are_followed_to_completion() -> None:
     rates = _octopus().get_electricity_rates(PRODUCT_CODE, TARIFF_CODE)
 
     assert [r.unit_rate for r in rates] == [Decimal("24.53"), Decimal("26.10")]
+
+
+@responses.activate
+def test_a_non_utc_period_is_normalized_to_utc_z_format_in_the_request() -> None:
+    responses.add(
+        responses.GET,
+        UNIT_RATES_ENDPOINT,
+        json={"results": [], "next": None},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        STANDING_CHARGES_ENDPOINT,
+        json={"results": [], "next": None},
+        status=200,
+    )
+    bst = timezone(timedelta(hours=1))
+    period_from = datetime(2024, 1, 6, 0, 0, 0, tzinfo=bst)
+    period_to = datetime(2024, 5, 24, 0, 0, 0, tzinfo=bst)
+
+    _octopus().get_electricity_rates(
+        PRODUCT_CODE, TARIFF_CODE, period_from=period_from, period_to=period_to
+    )
+
+    request_url = responses.calls[0].request.url
+    assert request_url is not None
+    assert "period_from=2024-01-05T23%3A00%3A00Z" in request_url
+    assert "period_to=2024-05-23T23%3A00%3A00Z" in request_url
+    assert "+" not in request_url

--- a/tests/test_electricity_rate_seam.py
+++ b/tests/test_electricity_rate_seam.py
@@ -177,20 +177,38 @@ def test_a_non_utc_period_is_normalized_to_utc_z_format_in_the_request() -> None
     responses.add(
         responses.GET,
         UNIT_RATES_ENDPOINT,
-        json={"results": [], "next": None},
+        json={
+            "results": [
+                {
+                    "value_inc_vat": 24.53,
+                    "valid_from": "2024-01-06T00:00:00Z",
+                    "valid_to": "2024-01-06T00:30:00Z",
+                }
+            ],
+            "next": None,
+        },
         status=200,
     )
     responses.add(
         responses.GET,
         STANDING_CHARGES_ENDPOINT,
-        json={"results": [], "next": None},
+        json={
+            "results": [
+                {
+                    "value_inc_vat": 48.20,
+                    "valid_from": "2024-01-06T00:00:00Z",
+                    "valid_to": None,
+                }
+            ],
+            "next": None,
+        },
         status=200,
     )
     bst = timezone(timedelta(hours=1))
     period_from = datetime(2024, 1, 6, 0, 0, 0, tzinfo=bst)
     period_to = datetime(2024, 5, 24, 0, 0, 0, tzinfo=bst)
 
-    _octopus().get_electricity_rates(
+    rates = _octopus().get_electricity_rates(
         PRODUCT_CODE, TARIFF_CODE, period_from=period_from, period_to=period_to
     )
 
@@ -199,3 +217,6 @@ def test_a_non_utc_period_is_normalized_to_utc_z_format_in_the_request() -> None
     assert "period_from=2024-01-05T23%3A00%3A00Z" in request_url
     assert "period_to=2024-05-23T23%3A00%3A00Z" in request_url
     assert "+" not in request_url
+    assert len(rates) == 1
+    assert rates[0].unit_rate == Decimal("24.53")
+    assert rates[0].standing_charge == Decimal("48.20")

--- a/tests/test_pricing_retrieval.py
+++ b/tests/test_pricing_retrieval.py
@@ -1,7 +1,9 @@
+import logging
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional
 
+import pytest
 import responses
 from common.config import OctopusAPISettings
 from data.mysql import sql_models
@@ -475,6 +477,7 @@ def test_refresh_skips_a_dual_register_only_product_without_crashing(
 @responses.activate
 def test_a_failing_agreement_s_rate_fetch_is_skipped_without_blocking_others(
     mariadb_client: MariaDBClient,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     responses.add(
         responses.GET, PRODUCTS_ENDPOINT, json={"results": [], "next": None}, status=200
@@ -491,18 +494,24 @@ def test_a_failing_agreement_s_rate_fetch_is_skipped_without_blocking_others(
     gas_meter = _make_gas_meter()
     source = _make_source(mariadb_client, [electricity_meter, gas_meter])
 
-    PricingRetriever(source).refresh()
+    with caplog.at_level(logging.WARNING):
+        PricingRetriever(source).refresh()
 
     with mariadb_client.session_read_scope() as session:
         stored = session.query(sql_models.product_rate).all()
 
     assert len(stored) == 1
     assert stored[0].unit_rate == Decimal("6.89")
+    assert any(
+        "VAR-22-11-01/E-1R-VAR-22-11-01-A" in record.message
+        for record in caplog.records
+    )
 
 
 @responses.activate
 def test_a_failing_comparison_product_s_rate_fetch_is_skipped_without_blocking_others(
     mariadb_client: MariaDBClient,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     responses.add(
         responses.GET,
@@ -556,13 +565,18 @@ def test_a_failing_comparison_product_s_rate_fetch_is_skipped_without_blocking_o
     )
     source = _make_source(mariadb_client, [])
 
-    PricingRetriever(source).refresh()
+    with caplog.at_level(logging.WARNING):
+        PricingRetriever(source).refresh()
 
     with mariadb_client.session_read_scope() as session:
         stored = session.query(sql_models.product_rate).all()
 
     assert len(stored) == 1
     assert stored[0].product_code == "AGILE-24-10-01"
+    assert any(
+        "VAR-22-11-01/E-1R-VAR-22-11-01-H" in record.message
+        for record in caplog.records
+    )
 
 
 @responses.activate

--- a/tests/test_pricing_retrieval.py
+++ b/tests/test_pricing_retrieval.py
@@ -473,6 +473,99 @@ def test_refresh_skips_a_dual_register_only_product_without_crashing(
 
 
 @responses.activate
+def test_a_failing_agreement_s_rate_fetch_is_skipped_without_blocking_others(
+    mariadb_client: MariaDBClient,
+) -> None:
+    responses.add(
+        responses.GET, PRODUCTS_ENDPOINT, json={"results": [], "next": None}, status=200
+    )
+    responses.add(
+        responses.GET,
+        "https://api.octopus.energy/v1/products/VAR-22-11-01/electricity-tariffs/"
+        "E-1R-VAR-22-11-01-A/standard-unit-rates/",
+        json={"detail": "Bad request"},
+        status=400,
+    )
+    _mock_gas_rate_endpoints()
+    electricity_meter = _make_electricity_meter()
+    gas_meter = _make_gas_meter()
+    source = _make_source(mariadb_client, [electricity_meter, gas_meter])
+
+    PricingRetriever(source).refresh()
+
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(sql_models.product_rate).all()
+
+    assert len(stored) == 1
+    assert stored[0].unit_rate == Decimal("6.89")
+
+
+@responses.activate
+def test_a_failing_comparison_product_s_rate_fetch_is_skipped_without_blocking_others(
+    mariadb_client: MariaDBClient,
+) -> None:
+    responses.add(
+        responses.GET,
+        PRODUCTS_ENDPOINT,
+        json={
+            "results": [
+                {
+                    "code": "VAR-22-11-01",
+                    "display_name": "Flexible Octopus",
+                    "direction": "IMPORT",
+                },
+                {
+                    "code": "AGILE-24-10-01",
+                    "display_name": "Agile Octopus",
+                    "direction": "IMPORT",
+                },
+            ],
+            "next": None,
+        },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        PRODUCTS_ENDPOINT + "VAR-22-11-01/",
+        json={
+            "single_register_electricity_tariffs": {
+                "H": {"direct_debit_monthly": {"code": "E-1R-VAR-22-11-01-H"}}
+            }
+        },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        PRODUCTS_ENDPOINT + "AGILE-24-10-01/",
+        json={
+            "single_register_electricity_tariffs": {
+                "H": {"direct_debit_monthly": {"code": "E-1R-AGILE-24-10-01-H"}}
+            }
+        },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.octopus.energy/v1/products/VAR-22-11-01/electricity-tariffs/"
+        "E-1R-VAR-22-11-01-H/standard-unit-rates/",
+        json={"detail": "Bad request"},
+        status=400,
+    )
+    _mock_electricity_rate_endpoints(
+        product_code="AGILE-24-10-01", tariff_code="E-1R-AGILE-24-10-01-H"
+    )
+    source = _make_source(mariadb_client, [])
+
+    PricingRetriever(source).refresh()
+
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(sql_models.product_rate).all()
+
+    assert len(stored) == 1
+    assert stored[0].product_code == "AGILE-24-10-01"
+
+
+@responses.activate
 def test_refresh_does_not_refetch_the_account_s_own_product_during_the_comparison_pass(
     mariadb_client: MariaDBClient,
 ) -> None:

--- a/tests/test_refresh_scheduling.py
+++ b/tests/test_refresh_scheduling.py
@@ -6,7 +6,12 @@ from data.consumption import ConsumptionRetriever
 from data.mysql import sql_models
 from data.mysql.client import MariaDBClient
 from data.pricing import PricingRetriever
-from main import register_jobs, register_pricing_job, run_pending_safely
+from main import (
+    register_jobs,
+    register_pricing_job,
+    run_initial_pricing_sync,
+    run_pending_safely,
+)
 from schedule import Scheduler
 
 REFRESH_CONFIG = RefreshSettings(refresh_interval=4, historical_limit=45)
@@ -89,3 +94,10 @@ def test_run_pending_safely_does_not_propagate_a_scheduled_job_failure() -> None
     scheduler.run_pending.side_effect = RuntimeError("boom")
 
     run_pending_safely(scheduler)
+
+
+def test_run_initial_pricing_sync_does_not_propagate_a_startup_failure() -> None:
+    pricing = Mock(spec=PricingRetriever)
+    pricing.refresh.side_effect = RuntimeError("Octopus API unavailable")
+
+    run_initial_pricing_sync(pricing)


### PR DESCRIPTION
## Summary

Found and reproduced live during the app's first real Raspberry Pi deployment: the app crash-looped indefinitely, re-running the full historical backfill on every restart, and never reached steady state.

- **Root cause**: `RateClient` (`app/data/octopus/rate.py`) built Octopus API request URLs by raw string concatenation. Its only encoding attempt special-cased exact UTC — any other timezone offset (e.g. British Summer Time, `+01:00`, in effect now) left a literal `+` in the query string, which Octopus's server reads as a space, rejecting the request with HTTP 400. Per [Guy Lipman's Octopus API guide](https://www.guylipman.com/octopus/api_guide.html) (a well-known community reference), the correct fix is to normalize to UTC/`Z` before sending — not merely encode the raw offset — since the guide warns local offsets can cause inconsistent behavior around DST transitions regardless of encoding. Now built via a `params` dict passed to `requests`, with `period_from`/`period_to` normalized to UTC first.
- **Blast radius**: this single failure was fatal to the whole app — `PricingRetriever`'s per-agreement/per-product loops propagated any exception, and `main.py`'s startup `pricing.refresh()` call had no exception handling at all (unlike the *scheduled* recurring pricing job). Both loops now log-and-continue on a per-item failure; the startup call is wrapped the same way via a new `run_initial_pricing_sync()` function.

Closes #395, closes #396.

## Test plan

- [x] Regression test reproduces the exact production bug (non-UTC `+01:00` offset) and asserts the request is UTC/`Z`-normalized with no raw `+`, and that rates still parse correctly.
- [x] Resilience tests: one failing agreement/product is logged (asserted via `caplog`) and skipped; others still sync.
- [x] `run_initial_pricing_sync` tested for non-propagation, mirroring the existing `run_pending_safely` pattern.
- [x] Full suite: 83 passed.
- [x] 3-round Standards + Spec review loop converged clean (2 consecutive zero-finding passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)