### PR TITLE
Exclude incomplete ISO weeks from Weekly YoY panels

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -129,7 +129,7 @@ The `daily_consumption_summary` table (`energy`, `date`, `total_kwh`, composite 
 _Avoid_: daily total, consumption rollup
 
 **Yearly Comparison**:
-The pair of Grafana panels (monthly total consumption over the trailing 12 months, and a week-over-week year-on-year % change by ISO week number, both split by energy) reading from `daily_consumption_summary`. ISO week numbering (MariaDB `YEARWEEK(date, 3)`) is used specifically to avoid the "week 0" ambiguity of calendar-week numbering and to avoid misattributing early-January/late-December boundary dates to the wrong week-year; an orphan week 53 (a year with no matching week 53 a year prior) falls back to comparing against that prior year's week 52.
+The pair of Grafana panels (monthly total consumption over the trailing 12 months, and a week-over-week year-on-year % change by ISO week number, both split by energy) reading from `daily_consumption_summary`. ISO week numbering (MariaDB `YEARWEEK(date, 3)`) is used specifically to avoid the "week 0" ambiguity of calendar-week numbering and to avoid misattributing early-January/late-December boundary dates to the wrong week-year; an orphan week 53 (a year with no matching week 53 a year prior) falls back to comparing against that prior year's week 52. The weekly panel only compares ISO weeks with all 7 days present (`HAVING COUNT(*) = 7`) — the current, still-in-progress week and the oldest weeks near the one-time 2-year backfill's non-week-aligned boundary can otherwise be short, understating totals and skewing the % change.
 _Avoid_: annual comparison, YoY chart
 
 **Cheap Window**:

--- a/.agent-docs/issues/bugfix-weekly-yoy-incomplete-weeks.md
+++ b/.agent-docs/issues/bugfix-weekly-yoy-incomplete-weeks.md
@@ -1,5 +1,7 @@
 # Issues: bugfix-weekly-yoy-incomplete-weeks
 
+> Work complete — PR ready to merge.
+
 ## Exclude incomplete ISO weeks from Weekly YoY panels (#418)
 
 **Blocked by**: None
@@ -38,18 +40,18 @@ completeness guard. Documentation-only — no application code changes.
 
 ### Acceptance criteria
 
-- [ ] `HAVING COUNT(*) = 7` (or equivalent) added to the `weekly` CTE in
+- [x] `HAVING COUNT(*) = 7` (or equivalent) added to the `weekly` CTE in
       both the electricity and gas Weekly YoY queries in
       `grafana/mariadb/queries.md`
-- [ ] An inline comment explains why the guard exists (in-progress current
+- [x] An inline comment explains why the guard exists (in-progress current
       week + partial backfill-boundary week), consistent with the file's
       existing comment conventions
-- [ ] The week-53 fallback logic still correctly falls back to week 52 when
+- [x] The week-53 fallback logic still correctly falls back to week 52 when
       week 53 is either missing entirely or present-but-incomplete
-- [ ] No application code changes — `app/` is untouched
-- [ ] `.agent-docs/context.md`'s `Yearly Comparison` entry mentions that
+- [x] No application code changes — `app/` is untouched
+- [x] `.agent-docs/context.md`'s `Yearly Comparison` entry mentions that
       only complete (7-day) ISO weeks are compared, and why
-- [ ] Manually reasoned through against: an up-to-date table, a partial
+- [x] Manually reasoned through against: an up-to-date table, a partial
       current week, a partial oldest week near the 730-day backfill cutoff,
       and the week-53-fallback case — and run against a real/test MariaDB
       instance if one is reachable

--- a/.agent-docs/issues/bugfix-weekly-yoy-incomplete-weeks.md
+++ b/.agent-docs/issues/bugfix-weekly-yoy-incomplete-weeks.md
@@ -1,0 +1,57 @@
+# Issues: bugfix-weekly-yoy-incomplete-weeks
+
+## Exclude incomplete ISO weeks from Weekly YoY panels (#418)
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3
+
+### What to build
+
+Add a `HAVING COUNT(*) = 7` guard to the `weekly` CTE in both the
+electricity and gas "Weekly Year-on-Year Change" queries in
+`grafana/mariadb/queries.md` (Row 4 — Yearly Comparison). Since
+`daily_consumption_summary` has a composite `(energy, date)` primary key and
+`weekly` is already filtered to a single energy before grouping by
+`YEARWEEK(date, 3)`, `COUNT(*) = 7` after that `GROUP BY` means exactly "all
+7 days of this ISO week are present."
+
+This single change removes incomplete weeks from `weekly` before either the
+`target` or comparator side reads from it, so:
+
+- An incomplete current (still in-progress) week never appears as a target
+  row — no partial-week data point on the chart.
+- An incomplete week near the 2-year backfill boundary never gets used as a
+  comparator — the `LEFT JOIN weekly c` naturally yields `NULL`, so
+  `yoy_pct_change` and the 4-week average are `NULL` for that point (target
+  week still shown on the x-axis) rather than computed against a partial
+  denominator.
+- The existing week-53 fallback (`(yearweek - 100) NOT IN (SELECT yearweek
+  FROM weekly)`) is unaffected — it already checks against `weekly`, so an
+  incomplete week 53 correctly falls back to week 52.
+
+Add an inline SQL comment next to the new `HAVING` clause explaining why a
+week can be short (in-progress week or backfill-boundary week), matching
+the existing comment style used for the week-53 fallback. Update the
+`Yearly Comparison` entry in `.agent-docs/context.md` to mention the
+completeness guard. Documentation-only — no application code changes.
+
+### Acceptance criteria
+
+- [ ] `HAVING COUNT(*) = 7` (or equivalent) added to the `weekly` CTE in
+      both the electricity and gas Weekly YoY queries in
+      `grafana/mariadb/queries.md`
+- [ ] An inline comment explains why the guard exists (in-progress current
+      week + partial backfill-boundary week), consistent with the file's
+      existing comment conventions
+- [ ] The week-53 fallback logic still correctly falls back to week 52 when
+      week 53 is either missing entirely or present-but-incomplete
+- [ ] No application code changes — `app/` is untouched
+- [ ] `.agent-docs/context.md`'s `Yearly Comparison` entry mentions that
+      only complete (7-day) ISO weeks are compared, and why
+- [ ] Manually reasoned through against: an up-to-date table, a partial
+      current week, a partial oldest week near the 730-day backfill cutoff,
+      and the week-53-fallback case — and run against a real/test MariaDB
+      instance if one is reachable
+
+---

--- a/.agent-docs/specs/bugfix-weekly-yoy-incomplete-weeks.md
+++ b/.agent-docs/specs/bugfix-weekly-yoy-incomplete-weeks.md
@@ -1,0 +1,131 @@
+# Weekly YoY Panel: Exclude Incomplete Weeks
+
+## Problem Statement
+
+The Weekly Year-on-Year Change panels (`grafana/mariadb/queries.md`, Row 4 —
+Yearly Comparison) treat every `YEARWEEK(date, 3)` bucket in
+`daily_consumption_summary` as a full 7-day week, with no check that it
+actually is. Two situations currently produce misleading numbers:
+
+1. **The current, still-in-progress ISO week** is always included as the
+   most recent target row. `daily_consumption_summary` is refreshed on every
+   app startup and every Monday (`ConsumptionSummaryRetriever.refresh`),
+   which recomputes a trailing 14-day window including today — so "today"
+   carries whatever partial/lagged consumption exists, not a full day's
+   total. That partial day rolls into the current week's `SUM(total_kwh)`,
+   which then gets compared against a *complete* week from a year earlier.
+   The result is an artificial YoY dip on the most recent point, and because
+   the 4-week moving average trails over `t.yearweek`, the dip also drags
+   down the last several points of the smoothed series.
+2. **The oldest comparator week**, at the edge of the one-time 2-year
+   backfill (`ConsumptionSummaryBackfill`, `BACKFILL_WINDOW_DAYS = 730`), can
+   also be partial. The backfill cutoff is a fixed day-count anchored to
+   midnight UTC, not aligned to an ISO week boundary, so the earliest date in
+   `daily_consumption_summary` lands mid-week. The 52-week chart's oldest
+   target row is ISO-week ~52 weeks ago; its comparator (`yearweek - 100`) is
+   ~104 weeks ago — right at that 730-day boundary. The left edge of the
+   chart can end up comparing against an artificially low (partial)
+   denominator.
+
+Both are the same root cause: nothing filters out weeks with fewer than 7
+summarized days, on either the target or comparator side.
+
+## Solution
+
+Only compare ISO weeks that have a full 7 days of summarized data in
+`daily_consumption_summary`, on both the target and comparator side. A week
+lacking any day's summary (whether because it hasn't finished yet, because
+it falls just outside the 2-year backfill's boundary, or because of any
+future data gap — meter downtime, a missed job run) is treated as
+incomplete and excluded, using the same mechanism regardless of cause.
+
+- If the **target** week is incomplete, it does not appear as a data point
+  in the chart at all — there is nothing sensible to plot for a week whose
+  own total isn't final.
+- If the target week is complete but its **comparator** week is incomplete,
+  the target week still appears on the x-axis, but `yoy_pct_change` and the
+  4-week moving average are `NULL` for that point — the same pattern
+  already used for the week-53 fallback when no comparator exists at all.
+
+## User Stories
+
+1. As the account holder, I want the most recent point on the Weekly YoY
+   chart to reflect a fully-finished week, so that I don't see a misleading
+   artificial dip every time I open the dashboard mid-week.
+2. As the account holder, I want the 4-week moving average to only be
+   computed over complete weeks, so that a partial current week doesn't
+   drag down the trend line for several weeks running.
+3. As the account holder, I want the oldest points on the chart (near the
+   2-year backfill boundary) to not show a distorted comparison caused by a
+   partial historical week, so that the chart doesn't need special
+   knowledge of when the backfill happened to be trusted.
+
+## Implementation Decisions
+
+- **Modules changed**: `grafana/mariadb/queries.md` only (Row 4 — Yearly
+  Comparison, "Weekly Year-on-Year Change" panels for electricity and gas).
+  No application code changes — this is a query-only fix, consistent with
+  how the panels originally shipped.
+- **Mechanism**: add `HAVING COUNT(*) = 7` to the `weekly` CTE in both the
+  electricity and gas queries. `daily_consumption_summary` has a true
+  composite `(energy, date)` primary key (ADR-0008), and `weekly` is already
+  filtered to a single energy before grouping by `YEARWEEK(date, 3)`, so
+  `COUNT(*)` after that `GROUP BY` is exactly "number of distinct days
+  present in this ISO week" — no `DISTINCT` needed.
+- **Why one change covers both bugs**: `target` is built `FROM weekly`, so
+  an incomplete current week is automatically excluded from ever being a
+  target row. The comparator join (`LEFT JOIN weekly c ON c.yearweek =
+  t.comparator_yearweek`) automatically yields `NULL` for `c.weekly_kwh`
+  when the comparator week was filtered out of `weekly` for being
+  incomplete — which combined with `NULLIF(c.weekly_kwh, 0)` already
+  produces `NULL` for `yoy_pct_change`, satisfying the "point still shown,
+  null %" behavior without further changes.
+- **Interaction with the existing week-53 fallback**: unaffected. The
+  fallback's `(yearweek - 100) NOT IN (SELECT yearweek FROM weekly)` check
+  now also correctly treats an incomplete week 53 as "doesn't exist" and
+  falls back to week 52, which is the desired behavior.
+- **Inline SQL comment**: add a short comment next to the new `HAVING`
+  clause explaining the rationale (in-progress week + backfill-boundary
+  week both being reasons a week can be short), matching the existing
+  inline-comment convention used for the week-53 fallback in this file.
+- **Glossary update**: extend the `Yearly Comparison` entry in
+  `.agent-docs/context.md` to mention that only complete (7-day) ISO weeks
+  are compared, and why.
+
+## Testing Decisions
+
+- **No automated test.** `YEARWEEK` and the window-function moving average
+  are MariaDB-specific and not supported by the SQLite in-memory fixtures
+  used elsewhere in this repo's test suite (e.g.
+  `test_agreement_persistence.py`). The original two Yearly Comparison
+  panels shipped the same way — documentation-only, validated by reasoning
+  through the SQL rather than an automated test.
+- **Validation approach**: reason through the SQL against representative
+  cases (a fully up-to-date table, a table with a partial current week, a
+  table with a partial oldest week near a 730-day-ago cutoff, and the
+  week-53-fallback case) and, if a real or test MariaDB instance is
+  reachable, run the query against it manually before merging.
+
+## Out of Scope
+
+- The Monthly Total Consumption panel has an analogous partial-current-month
+  issue (the current month's bar is short because the month isn't over
+  yet), but it's a less severe bug — a short bar, not a misleading
+  percentage swing — and is not part of this fix.
+- No change to `ConsumptionSummaryBackfill`, `ConsumptionSummaryRetriever`,
+  or the `BACKFILL_WINDOW_DAYS` constant. The fix is entirely on the query
+  side; the underlying data-population code is unchanged.
+- No change to the 52-week window size (still `yearweek >= YEARWEEK(CURDATE()
+  - INTERVAL 52 WEEK, 3)`) — excluding the current incomplete week simply
+  means the chart's rightmost point is the most recent *complete* week,
+  narrowing the effective display to ~51-52 complete weeks rather than
+  widening the lower bound to compensate.
+
+## Further Notes
+
+Investigated and agreed via `/design` session prior to this spec. Both
+issues were confirmed by reading `ConsumptionSummaryRetriever.refresh`
+(`app/data/consumption_summary.py`), `read_consumption_summarization_window`
+(`app/data/mysql/client.py`), and `ConsumptionSummaryBackfill.run`
+(`app/data/consumption_summary.py`) alongside the existing query in
+`grafana/mariadb/queries.md`.

--- a/grafana/mariadb/queries.md
+++ b/grafana/mariadb/queries.md
@@ -390,6 +390,10 @@ WITH weekly AS (
   FROM daily_consumption_summary
   WHERE energy = 'E'
   GROUP BY YEARWEEK(date, 3)
+  -- Completeness guard: only compare weeks with all 7 days present. The
+  -- current, still-in-progress ISO week never has 7 days yet, and the
+  -- oldest weeks near the one-time 2-year backfill's boundary can also be
+  -- short since that cutoff isn't week-aligned.
   HAVING COUNT(*) = 7
 ),
 target AS (
@@ -433,6 +437,7 @@ WITH weekly AS (
   FROM daily_consumption_summary
   WHERE energy = 'G'
   GROUP BY YEARWEEK(date, 3)
+  -- Completeness guard: see the electricity panel above for the rationale.
   HAVING COUNT(*) = 7
 ),
 target AS (

--- a/grafana/mariadb/queries.md
+++ b/grafana/mariadb/queries.md
@@ -382,12 +382,15 @@ ORDER BY MIN(date);
 
 Groups by `YEARWEEK(date, 3)` (ISO week numbering, mode 3) rather than `YEAR(date)` paired separately with `WEEK(date, 3)` — the latter can misattribute early-January/late-December boundary dates to the wrong week-year, exactly what ISO week numbering exists to avoid. Each week is compared against the same ISO week number one year prior (`yearweek - 100`, e.g. `202630 - 100 = 202530` — subtracting 100 shifts back exactly one week-year while preserving the week number). Both the raw % change and a 4-week trailing moving average of it are returned as separate columns for the same panel.
 
+`weekly` only keeps weeks with all 7 days present (`HAVING COUNT(*) = 7`) — the current, still-in-progress ISO week never has 7 days yet, and the oldest weeks near the one-time 2-year backfill's boundary can also be short since that cutoff isn't week-aligned. Filtering incomplete weeks out of `weekly` before `target` and the comparator join both read from it means: an incomplete current week never becomes a target row (nothing sensible to plot for a week that isn't over), and an incomplete comparator week naturally produces a `NULL` `yoy_pct_change` via the `LEFT JOIN` (target week still shown, just no % for that point) instead of dividing against a partial total.
+
 ```sql
 WITH weekly AS (
   SELECT YEARWEEK(date, 3) AS yearweek, SUM(total_kwh) AS weekly_kwh
   FROM daily_consumption_summary
   WHERE energy = 'E'
   GROUP BY YEARWEEK(date, 3)
+  HAVING COUNT(*) = 7
 ),
 target AS (
   SELECT
@@ -422,12 +425,15 @@ ORDER BY t.yearweek;
 
 ### Weekly Year-on-Year Change — Last 52/53 Weeks, Gas (time series)
 
+Same completeness guard as the electricity panel above — see its description for the rationale.
+
 ```sql
 WITH weekly AS (
   SELECT YEARWEEK(date, 3) AS yearweek, SUM(total_kwh) AS weekly_kwh
   FROM daily_consumption_summary
   WHERE energy = 'G'
   GROUP BY YEARWEEK(date, 3)
+  HAVING COUNT(*) = 7
 ),
 target AS (
   SELECT


### PR DESCRIPTION
## Summary

- The Weekly Year-on-Year Change panels (`grafana/mariadb/queries.md`) grouped `daily_consumption_summary` by ISO week with no check that a week actually had 7 days of data, so the still-in-progress current week and the oldest week near the one-time 2-year backfill's non-week-aligned boundary could distort the % change shown.
- Adds `HAVING COUNT(*) = 7` to the `weekly` CTE in both the electricity and gas panels, which naturally excludes an incomplete current week from ever being a target row, and produces a `NULL` `yoy_pct_change` (target week still shown) when the comparator week is incomplete.
- Documentation-only fix — no application code changed.

Closes #418

## Test plan

- [x] Manually validated against a throwaway MariaDB container seeded with synthetic data covering: a partial current week, a partial backfill-boundary comparator week, and the week-53 fallback case — confirmed the fix produces the expected output with no regression on healthy complete weeks.
- [x] Pre-commit hooks pass (markdownlint, codespell, link check, pytest).
- [x] Two-axis code review (Standards + Spec) run to two consecutive clean passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)