### PR TITLE
Fix current-agreement lookup to use range containment, not valid_to IS NULL

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -61,7 +61,7 @@ _Avoid_: customer, user
 ### Data Storage
 
 **MariaDB `octopus` database**:
-The sole active persistence store for this app. The database itself is created by `mariadb/init.sql`; every table inside it is defined solely by `app/data/mysql/model.py` (see **Schema Sync**) and includes `consumption`, `agreement`, `product`, `product_rate`, and `job_run`.
+The sole active persistence store for this app. The database itself is created by `mariadb/init.sql`; every table inside it is defined solely by `app/data/mysql/model.py` (see **Schema Sync**) and includes `consumption`, `agreement`, `product`, `product_rate`, `daily_consumption_summary`, `agile_forecast`, `cost_forecast`, and `job_run`.
 _Avoid_: the database, mysql db
 
 **Schema Sync**:

--- a/.agent-docs/issues/bugfix-cost-forecast-current-agreement-range.md
+++ b/.agent-docs/issues/bugfix-cost-forecast-current-agreement-range.md
@@ -1,5 +1,7 @@
 # Issues: bugfix-cost-forecast-current-agreement-range
 
+> Work complete — PR ready to merge.
+
 ## Fix current-agreement lookup to use range containment, not valid_to IS NULL
 
 **GitHub issue**: #425
@@ -21,14 +23,14 @@ regression test with a bounded, non-`None` `valid_to` that still spans
 
 ### Acceptance criteria
 
-- [ ] `_current_electricity_agreement(as_of)` selects an agreement using
+- [x] `_current_electricity_agreement(as_of)` selects an agreement using
       `valid_from <= as_of and (valid_to is None or as_of < valid_to)`.
-- [ ] `refresh()` passes `as_of` through to `_current_electricity_agreement`.
-- [ ] New test: a current agreement with a bounded `valid_to` spanning
+- [x] `refresh()` passes `as_of` through to `_current_electricity_agreement`.
+- [x] New test: a current agreement with a bounded `valid_to` spanning
       `as_of` results in `refresh()` succeeding and persisting a forecast row.
-- [ ] Existing test `test_no_current_agreement_raises_a_clear_error` still
+- [x] Existing test `test_no_current_agreement_raises_a_clear_error` still
       passes against the reworded error message.
-- [ ] All other existing tests in `tests/test_cost_forecast_retriever.py`
+- [x] All other existing tests in `tests/test_cost_forecast_retriever.py`
       still pass unchanged.
 
 ---

--- a/.agent-docs/issues/bugfix-cost-forecast-current-agreement-range.md
+++ b/.agent-docs/issues/bugfix-cost-forecast-current-agreement-range.md
@@ -1,0 +1,34 @@
+# Issues: bugfix-cost-forecast-current-agreement-range
+
+## Fix current-agreement lookup to use range containment, not valid_to IS NULL
+
+**GitHub issue**: #425
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3
+
+### What to build
+
+Change `CostForecastRetriever._current_electricity_agreement()` to take
+`as_of: datetime` and select the electricity agreement whose
+`[valid_from, valid_to)` range contains `as_of` (`valid_to IS NULL` treated
+as unbounded), instead of requiring `valid_to IS NULL` outright. Thread
+`as_of` through from `refresh()`, which already has it in scope. Reword the
+no-match `RuntimeError` since "open-ended" is no longer the criterion. Add a
+regression test with a bounded, non-`None` `valid_to` that still spans
+`as_of`, matching the real Agile-account fixture shape that exposed this bug.
+
+### Acceptance criteria
+
+- [ ] `_current_electricity_agreement(as_of)` selects an agreement using
+      `valid_from <= as_of and (valid_to is None or as_of < valid_to)`.
+- [ ] `refresh()` passes `as_of` through to `_current_electricity_agreement`.
+- [ ] New test: a current agreement with a bounded `valid_to` spanning
+      `as_of` results in `refresh()` succeeding and persisting a forecast row.
+- [ ] Existing test `test_no_current_agreement_raises_a_clear_error` still
+      passes against the reworded error message.
+- [ ] All other existing tests in `tests/test_cost_forecast_retriever.py`
+      still pass unchanged.
+
+---

--- a/.agent-docs/specs/bugfix-cost-forecast-current-agreement-range.md
+++ b/.agent-docs/specs/bugfix-cost-forecast-current-agreement-range.md
@@ -1,0 +1,97 @@
+# Cost forecast: current-agreement lookup must handle bounded valid_to
+
+## Problem Statement
+
+`cost_forecast.refresh()` fails every time it runs for accounts whose current
+electricity agreement has a real (non-null) `valid_to` — which is the normal
+shape for Agile-tariff accounts, since Octopus renews Agile contracts as
+fixed one-year terms and never returns `valid_to: null`, not even for the
+currently-active agreement. Confirmed live on a real Agile-tariff account:
+the daily 04:00 scheduled job and the startup call both catch and log the
+resulting `RuntimeError` non-fatally, so the failure is silent in normal
+operation — but permanent. `agile_forecast` and `cost_forecast` stay
+permanently empty for any account in this shape.
+
+## Solution
+
+`CostForecastRetriever._current_electricity_agreement()` selects "current" by
+range-containment (`valid_from <= as_of AND (valid_to IS NULL OR as_of <
+valid_to)`) instead of requiring `valid_to IS NULL`. This matches the
+convention already used elsewhere in this codebase for the same kind of
+lookup (`app/data/mysql/client.py`'s `read_current_product_rate` and the
+consumption-to-agreement join), so agreements with a bounded `valid_to` that
+still covers `as_of` are found correctly, while genuinely open-ended
+agreements (`valid_to IS NULL`) keep working exactly as before.
+
+## User Stories
+
+1. As the daily cost-forecast job, I want to find the electricity agreement
+   that covers "now" even when that agreement has a real end date, so that
+   `refresh()` succeeds for Agile-tariff accounts instead of raising every
+   time it runs.
+2. As a developer reading this code, I want the "current agreement" lookup to
+   use the same range-containment convention as the other "current as of a
+   point in time" lookups in this codebase, so that the logic is predictable
+   and consistent across the pricing pipeline.
+3. As the cost-forecast job, I want a clear, actionable error when no
+   agreement's range actually contains `as_of` (e.g. a genuine gap between
+   one contract ending and its renewal starting), so that failures remain
+   loud rather than silently producing a wrong forecast.
+
+## Implementation Decisions
+
+- `app/data/cost_forecast.py`: `_current_electricity_agreement()` gains a
+  required `as_of: datetime` parameter. Its selection predicate changes from
+  `a.valid_to is None` to `a.valid_from <= as_of and (a.valid_to is None or
+  as_of < a.valid_to)`.
+- The call site in `refresh()` (already has `as_of` in scope) passes it
+  through: `self._current_electricity_agreement(as_of)`.
+- The `RuntimeError` message for the no-match case is reworded since "open-
+  ended" is no longer the criterion (still matches the existing test's
+  `"[Nn]o current .*agreement"` regex).
+- No change to `Agreement`, no change to any MySQL query — this is an
+  in-memory selection over `electricity_meter.agreements`, mirroring the
+  SQL-level pattern rather than moving the lookup into SQL.
+- Overlapping-agreement ambiguity is not defensively handled: `next()` takes
+  the first matching agreement in list order. Octopus's data model doesn't
+  produce overlapping agreements for one meter, and no real fixture has
+  shown this, so speculative handling isn't warranted.
+- No ADR: this mirrors an existing, already-decided convention rather than
+  introducing a new one.
+
+## Testing Decisions
+
+- Test at the existing seam: `CostForecastRetriever.refresh()` via the
+  `_RealCostForecastSource` test double in
+  `tests/test_cost_forecast_retriever.py` (real `MariaDBClient`/SQLite
+  fixture underneath, HTTP mocked via `responses`) — the same seam every
+  other test in that file already uses.
+- New regression test: a current agreement with a bounded, non-`None`
+  `valid_to` that still spans `as_of` (mirroring the real Agile account's
+  fixture shape) — asserts `refresh()` does not raise and persists a
+  forecast row. All 12 existing fixtures in this file use `valid_to=None`
+  for the current agreement, which structurally hid this exact bug.
+- Existing test `test_no_current_agreement_raises_a_clear_error` continues
+  to cover the genuine-no-match case (its agreement's `valid_to` already
+  precedes `as_of`) and should still pass unchanged against the reworded
+  error message, since the regex only checks for `"no current .*agreement"`.
+- No changes needed to the other 11 existing tests — unaffected, still valid
+  coverage for the open-ended (`valid_to IS NULL`) case.
+
+## Out of Scope
+
+- The Pi redeployment and resumption of the paused live-monitoring window
+  (manual follow-up once this merges and CI publishes a new image).
+- The CI push-trigger investigation (separate, already owned by another
+  agent per the handoff).
+- The `pi-desktop/docker/docker-compose.yml` service-definition merge
+  (tracked separately, file-edit-only, no redeploy of that stack).
+
+## Further Notes
+
+Handoff document: `octopus-monitoring-handoff-9.md`. Investigation already
+confirmed live against the Pi deployment's real `agreement` table for a real
+Agile-tariff account (see handoff for the exact row shapes observed). Same
+masking pattern already flagged in the PR #423 review per project memory
+(`project_octopus_monitoring_pricing_pipeline`) — fixture data that
+coincidentally simplifies away the real-world case.

--- a/.agent-docs/specs/dns-resilience-and-session-reuse.md
+++ b/.agent-docs/specs/dns-resilience-and-session-reuse.md
@@ -1,0 +1,154 @@
+# Reduce DNS-resolution failure exposure: persistent session reuse + fallback resolver
+
+## Problem Statement
+
+Found live during this session's first real Pi deployment monitoring of
+`octopus-monitoring`: intermittent `NameResolutionError` warnings against
+`api.octopus.energy`, e.g. `Failed to resolve 'api.octopus.energy' ([Errno -3]
+Try again)`. Self-healed every time by the existing `@retry()` decorator
+(non-fatal), but frequent enough during a historical backfill to be a real
+reliability concern rather than a one-off blip.
+
+Two contributing root causes, confirmed by direct investigation on the
+deployed container and Pi host:
+
+1. **`OctopusTransport.get()`** (`app/data/octopus/transport.py`) calls the
+   bare, module-level `requests.get(...)` on every single call rather than a
+   persistent `requests.Session`. Each such call opens a fresh connection,
+   forcing its own DNS lookup + TLS handshake. A historical backfill makes
+   hundreds of sequential paginated requests to the same host (observed
+   `page=1` through `page=193`+ for gas consumption alone in one run) — so
+   this multiplies exposure to any single transient DNS hiccup by roughly the
+   same factor, instead of resolving once and reusing a keep-alive connection
+   for the whole burst.
+2. **No DNS fallback.** Docker's embedded resolver (`127.0.0.11` inside the
+   container) forwards external queries to the host's one configured
+   nameserver, `192.168.0.50` — almost certainly the LAN's pi-hole box (per
+   `pi-desktop`'s own setup docs). There is no second resolver to fall back to
+   if that one is ever briefly slow or unresponsive.
+
+Ruled out as the cause: broken DNS/network connectivity in general. `api.
+octopus.energy` is genuine dual-stack (IPv4 `54.230.201.x` AWS CloudFront +
+IPv6), and 60 rapid manual `getent hosts` lookups from both the container and
+the Pi host all succeeded cleanly during the investigation. The failures are
+transient/load-related against a single resolver, not a fundamentally broken
+path.
+
+## Solution
+
+Two small, independent, complementary changes:
+
+1. `OctopusTransport`: replace the per-call `requests.get(...)` with a
+   `requests.Session()` created once and reused for the transport's lifetime.
+2. `docker-compose.yml`: add a fallback DNS resolver (Cloudflare `1.1.1.1`)
+   alongside the primary (`192.168.0.50`) on the `energy-monitor` service.
+
+## User Stories
+
+1. As the operator of this app, I want a historical backfill to make roughly
+   one DNS lookup instead of one *per request* for a burst of calls to the
+   same host, so a transient DNS hiccup has far less chance of landing during
+   that burst.
+2. As the operator of this app, I want the container to have a working
+   fallback DNS resolver, so a brief unresponsive spell from the LAN's primary
+   resolver doesn't cause a resolution failure at all.
+3. As a future maintainer, I want this change provable via the existing test
+   suite alone, without needing a live Pi redeployment to confirm it worked.
+
+## Implementation Decisions
+
+- **`OctopusTransport.__init__`**: create `self._session = requests.Session()`
+  and set `self._session.auth = (settings.api_key, "")` once here, instead of
+  passing `auth=(self._api_key, "")` on every call.
+- **`OctopusTransport.get()`**: call `self._session.get(...)` instead of the
+  module-level `requests.get(...)`. Everything else about the method (the
+  `@retry()` decorator, `REQUEST_TIMEOUT_SECONDS`, `raise_for_http_error`
+  handling) stays as-is.
+- **Session lifetime = transport lifetime = app process lifetime.**
+  `OctopusTransport` is constructed once, in `MonitoringClient.__init__`
+  (`app/data/base.py`), and already shared across every retriever —
+  including concurrent background job threads spawned by
+  `_run_with_backoff_in_background` in `main.py` (`consumption_refresh`,
+  `pricing_refresh`, `cost_forecast_refresh` each get their own thread). No
+  new locking is needed: `requests.Session`/urllib3's connection pool are
+  thread-safe for concurrent use — this is the standard use case session
+  reuse is designed for, not a new concurrency risk introduced by this
+  change.
+- **Stale/dropped reused connections are expected to self-heal via the
+  existing `@retry()` decorator** (3 attempts, retries on any exception) —
+  urllib3's connection pool evicts a dead pooled connection and opens a fresh
+  one on the retried call. No new retry logic needed; call out as a testable
+  assumption rather than a code change (see Testing Decisions).
+- **Explicitly out of scope, noted so a future reader isn't confused**:
+  `KrakenTransport` (`app/data/octopus/kraken.py`) and `AgilePredictClient`
+  (`app/data/octopus/agile_predict.py`) have the identical bare-`requests`
+  pattern, but are called once per daily refresh cycle rather than hundreds
+  of times per backfill — the amplification concern doesn't apply at that
+  call volume. Left as-is.
+- **`docker-compose.yml`**: add `dns: [192.168.0.50, 1.1.1.1]` to the
+  `energy-monitor` service only — `mariadb` makes no external calls and
+  doesn't need it. `192.168.0.50` stays listed first/primary (preserves
+  whatever LAN-local behavior the pi-hole resolver provides); `1.1.1.1` is
+  only consulted if the primary doesn't respond.
+- No ADR — this is a reliability hardening change following an established
+  pattern (persistent HTTP sessions are standard practice), not a new
+  architectural decision.
+
+## Testing Decisions
+
+- **`tests/test_octopus_transport.py`** (existing seam: the `responses`
+  library, which mocks at the transport/adapter layer and is compatible with
+  a session-based rewrite without needing new test infrastructure):
+  - All existing tests should continue to pass unmodified against the
+    session-based rewrite — session reuse must not change request/response
+    behavior for the happy path or any existing error-handling test.
+  - Add a test asserting session reuse itself: e.g. two separate `get()`
+    calls should be served by the same `requests.Session` instance (spy on
+    `Session.get`, or assert identity of `self._session` is stable across
+    calls) rather than asserting anything about actual DNS behavior (not
+    observable through `responses` mocking).
+  - Add a regression test for the self-healing assumption: simulate a
+    connection-level failure on the first attempt (e.g. a `responses` side
+    effect raising `ConnectionError`) followed by a successful response on
+    retry, and assert the overall `get()` call still succeeds via the
+    existing `@retry()` decorator — proving session reuse doesn't break the
+    retry path.
+- No live Pi redeployment is required to consider this done (explicit
+  constraint agreed this session) — re-running a live backfill and confirming
+  fewer/no `NameResolutionError` log lines is optional additional
+  confirmation, not a gate.
+- `docker-compose.yml`'s `dns:` addition has no automated test (compose
+  config, not application code) — verify by inspection, or `docker compose
+  config`, if desired.
+
+## Out of Scope
+
+- `KrakenTransport` / `AgilePredictClient` session reuse (see Implementation
+  Decisions) — same pattern, much lower call volume, left as-is.
+- A separate bug found in the same live-monitoring session: a `{'period_from':
+  ['Must not be greater than period_to.']}` 400 error in rate-fetching, for an
+  agreement whose `valid_from` equals its `valid_to` (a zero-width window).
+  Already handled gracefully today by `PricingRetriever`'s existing
+  try/except-and-skip around per-agreement rate sync (see
+  `bugfix-rate-fetch-url-encoding.md` for the established pattern this
+  follows) — not part of this DNS-focused fix. Worth a dedicated fix later if
+  it recurs often enough to matter.
+- Any change to `@retry()`'s attempt count or backoff timing in
+  `common/decorator.py`.
+- Driving DNS failures to literal zero — not achievable over a home network,
+  and not the agreed acceptance bar (see Further Notes).
+
+## Further Notes
+
+Found live during the same Pi deployment/monitoring session as
+`bugfix-cost-forecast-current-agreement-range.md` — both surfaced from the
+same live-monitoring window. Agreed acceptance bar: *meaningfully reduce* the
+frequency of DNS-caused failures, not eliminate them entirely; must be
+testable without a live Pi redeploy.
+
+This document intentionally lives on the `bugfix/cost-forecast-current-
+agreement-range` branch alongside the unrelated agreement-bug fix, rather
+than its own branch — an explicit, deliberate choice this session because two
+agents were working in parallel against one shared working directory. Pick a
+proper dedicated branch (e.g. `chore/dns-resilience-and-session-reuse`) when
+actually picking this up for implementation.

--- a/app/data/cost_forecast.py
+++ b/app/data/cost_forecast.py
@@ -120,7 +120,7 @@ class CostForecastRetriever:
         # over, and not guarded against here since it's outside Kraken's
         # documented behavior rather than a case this code can meaningfully
         # detect or correct for.
-        agreement = self._current_electricity_agreement()
+        agreement = self._current_electricity_agreement(as_of)
         daily_costs = self._client.read_elapsed_billing_period_costs(
             elapsed_start, as_of, self._client.region_code
         )
@@ -147,7 +147,7 @@ class CostForecastRetriever:
             f"projected total £{forecast.projected_total_cost}."
         )
 
-    def _current_electricity_agreement(self) -> Agreement:
+    def _current_electricity_agreement(self, as_of: datetime) -> Agreement:
         electricity_meter = next(
             (m for m in self._client.meters if m.energy == Energy.electricity), None
         )
@@ -155,13 +155,25 @@ class CostForecastRetriever:
             raise RuntimeError(
                 "No electricity meter found -- cannot compute a cost forecast."
             )
+        # "Current" = the agreement whose [valid_from, valid_to) range
+        # contains as_of, with valid_to=None treated as unbounded -- not
+        # "valid_to is None". Real Agile contracts renew as fixed one-year
+        # terms, so Octopus's API never returns valid_to=None for them, not
+        # even for the currently-active one; matching client.py's
+        # read_current_product_rate convention instead of requiring an
+        # open-ended row.
         agreement = next(
-            (a for a in electricity_meter.agreements if a.valid_to is None), None
+            (
+                a
+                for a in electricity_meter.agreements
+                if a.valid_from <= as_of and (a.valid_to is None or as_of < a.valid_to)
+            ),
+            None,
         )
         if agreement is None:
             raise RuntimeError(
-                "No current (open-ended) agreement found for the electricity "
-                "meter -- cannot compute a cost forecast."
+                "No current agreement found for the electricity meter as of "
+                f"{as_of} -- cannot compute a cost forecast."
             )
         return agreement
 

--- a/app/data/cost_forecast.py
+++ b/app/data/cost_forecast.py
@@ -159,9 +159,12 @@ class CostForecastRetriever:
         # contains as_of, with valid_to=None treated as unbounded -- not
         # "valid_to is None". Real Agile contracts renew as fixed one-year
         # terms, so Octopus's API never returns valid_to=None for them, not
-        # even for the currently-active one; matching client.py's
-        # read_current_product_rate convention instead of requiring an
-        # open-ended row.
+        # even for the currently-active one; mirrors the range-containment
+        # predicate client.py's read_current_product_rate uses instead of
+        # requiring an open-ended row. Unlike that query, this doesn't order
+        # by valid_from on a tie: Octopus's data model doesn't produce
+        # overlapping agreements for one meter, so the first match in
+        # response order is taken as-is (see spec for this fix).
         agreement = next(
             (
                 a

--- a/tests/test_cost_forecast_retriever.py
+++ b/tests/test_cost_forecast_retriever.py
@@ -83,6 +83,7 @@ class _RealCostForecastSource:
 
 def _make_electricity_meter(
     tariff_code: str = f"E-1R-{PRODUCT_CODE}-{REGION}",
+    valid_to: Optional[datetime] = None,
 ) -> Electricity:
     return Electricity(
         mpan="1234567890123",
@@ -91,7 +92,7 @@ def _make_electricity_meter(
             Agreement(
                 tariff_code=tariff_code,
                 valid_from=datetime(2022, 1, 1, tzinfo=timezone.utc),
-                valid_to=None,
+                valid_to=valid_to,
             )
         ],
     )
@@ -650,6 +651,70 @@ def test_no_current_agreement_raises_a_clear_error(
 
     with pytest.raises(RuntimeError, match="[Nn]o current .*agreement"):
         retriever.refresh(as_of=datetime(2026, 7, 7, tzinfo=timezone.utc))
+
+
+@responses.activate
+def test_current_agreement_with_a_bounded_valid_to_still_matches(
+    mariadb_client: MariaDBClient,
+) -> None:
+    # Regression test: real Agile contracts renew as fixed one-year terms --
+    # Octopus's API never returns valid_to=None for them, not even for the
+    # currently-active agreement (confirmed live against a real account's
+    # agreement table). "Current" must mean "as_of falls within this
+    # agreement's range", not "this agreement has no end date".
+    _mock_billing_period("2026-07-06", "2026-08-06")
+
+    with mariadb_client.session_write_scope() as s:
+        s.add(
+            model.agreement(
+                id="E20220101000000",
+                energy="E",
+                product_code=PRODUCT_CODE,
+                tariff_code=f"E-1R-{PRODUCT_CODE}-{REGION}",
+                valid_from=datetime(2022, 1, 1, tzinfo=timezone.utc),
+                valid_to=None,
+            )
+        )
+        s.add(
+            model.product_rate(
+                id=f"{PRODUCT_CODE}_{REGION}_202601010000",
+                product_code=PRODUCT_CODE,
+                region=REGION,
+                valid_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                valid_to=None,
+                unit_rate=Decimal("20.00"),
+                standing_charge=Decimal("48.00"),
+            )
+        )
+        s.add(
+            model.consumption(
+                id="E20260706000000",
+                energy="E",
+                period_from=datetime(2026, 7, 6, 0, 0, tzinfo=timezone.utc),
+                period_to=datetime(2026, 7, 6, 0, 30, tzinfo=timezone.utc),
+                raw_value=Decimal("2.0"),
+                unit="kWh",
+                est_kwh=Decimal("2.0"),
+            )
+        )
+
+    retriever = CostForecastRetriever(
+        _source(
+            mariadb_client,
+            [
+                _make_electricity_meter(
+                    valid_to=datetime(2027, 5, 24, tzinfo=timezone.utc)
+                )
+            ],
+        )
+    )
+    retriever.refresh(as_of=datetime(2026, 7, 7, tzinfo=timezone.utc))
+
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(model.cost_forecast).all()
+
+    assert len(stored) == 1
+    assert stored[0].actual_cost_to_date == Decimal("0.88")
 
 
 @responses.activate

--- a/tests/test_cost_forecast_retriever.py
+++ b/tests/test_cost_forecast_retriever.py
@@ -83,17 +83,16 @@ class _RealCostForecastSource:
 
 def _make_electricity_meter(
     tariff_code: str = f"E-1R-{PRODUCT_CODE}-{REGION}",
+    valid_from: datetime = datetime(2022, 1, 1, tzinfo=timezone.utc),
     valid_to: Optional[datetime] = None,
+    prior_agreements: Optional[List[Agreement]] = None,
 ) -> Electricity:
     return Electricity(
         mpan="1234567890123",
         serial_number="00A1234567",
-        agreements=[
-            Agreement(
-                tariff_code=tariff_code,
-                valid_from=datetime(2022, 1, 1, tzinfo=timezone.utc),
-                valid_to=valid_to,
-            )
+        agreements=(prior_agreements or [])
+        + [
+            Agreement(tariff_code=tariff_code, valid_from=valid_from, valid_to=valid_to)
         ],
     )
 
@@ -653,61 +652,71 @@ def test_no_current_agreement_raises_a_clear_error(
         retriever.refresh(as_of=datetime(2026, 7, 7, tzinfo=timezone.utc))
 
 
+def _seed_fixed_tariff_agreement_and_rate(s: Session) -> None:
+    # Feeds read_elapsed_billing_period_costs's DB-level consumption-to-
+    # agreement join only -- unrelated to _current_electricity_agreement's
+    # in-memory selection, which reads solely from the Electricity meter's
+    # Agreement list passed to CostForecastRetriever.
+    s.add(
+        model.agreement(
+            id="E20220101000000",
+            energy="E",
+            product_code=PRODUCT_CODE,
+            tariff_code=f"E-1R-{PRODUCT_CODE}-{REGION}",
+            valid_from=datetime(2022, 1, 1, tzinfo=timezone.utc),
+            valid_to=None,
+        )
+    )
+    s.add(
+        model.product_rate(
+            id=f"{PRODUCT_CODE}_{REGION}_202601010000",
+            product_code=PRODUCT_CODE,
+            region=REGION,
+            valid_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            valid_to=None,
+            unit_rate=Decimal("20.00"),
+            standing_charge=Decimal("48.00"),
+        )
+    )
+    s.add(
+        model.consumption(
+            id="E20260706000000",
+            energy="E",
+            period_from=datetime(2026, 7, 6, 0, 0, tzinfo=timezone.utc),
+            period_to=datetime(2026, 7, 6, 0, 30, tzinfo=timezone.utc),
+            raw_value=Decimal("2.0"),
+            unit="kWh",
+            est_kwh=Decimal("2.0"),
+        )
+    )
+
+
 @responses.activate
 def test_current_agreement_with_a_bounded_valid_to_still_matches(
     mariadb_client: MariaDBClient,
 ) -> None:
-    # Regression test: real Agile contracts renew as fixed one-year terms --
-    # Octopus's API never returns valid_to=None for them, not even for the
-    # currently-active agreement (confirmed live against a real account's
-    # agreement table). "Current" must mean "as_of falls within this
-    # agreement's range", not "this agreement has no end date".
+    # Regression test: real Agile contracts renew as fixed one-year terms, so
+    # Octopus's API never returns valid_to=None even for the currently-active
+    # agreement. Mirrors the real account's shape (a lapsed prior agreement
+    # plus a bounded current one) so the current one is proven to be selected
+    # by range, not merely "the only agreement present".
     _mock_billing_period("2026-07-06", "2026-08-06")
 
     with mariadb_client.session_write_scope() as s:
-        s.add(
-            model.agreement(
-                id="E20220101000000",
-                energy="E",
-                product_code=PRODUCT_CODE,
-                tariff_code=f"E-1R-{PRODUCT_CODE}-{REGION}",
-                valid_from=datetime(2022, 1, 1, tzinfo=timezone.utc),
-                valid_to=None,
-            )
-        )
-        s.add(
-            model.product_rate(
-                id=f"{PRODUCT_CODE}_{REGION}_202601010000",
-                product_code=PRODUCT_CODE,
-                region=REGION,
-                valid_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
-                valid_to=None,
-                unit_rate=Decimal("20.00"),
-                standing_charge=Decimal("48.00"),
-            )
-        )
-        s.add(
-            model.consumption(
-                id="E20260706000000",
-                energy="E",
-                period_from=datetime(2026, 7, 6, 0, 0, tzinfo=timezone.utc),
-                period_to=datetime(2026, 7, 6, 0, 30, tzinfo=timezone.utc),
-                raw_value=Decimal("2.0"),
-                unit="kWh",
-                est_kwh=Decimal("2.0"),
-            )
-        )
+        _seed_fixed_tariff_agreement_and_rate(s)
 
-    retriever = CostForecastRetriever(
-        _source(
-            mariadb_client,
-            [
-                _make_electricity_meter(
-                    valid_to=datetime(2027, 5, 24, tzinfo=timezone.utc)
-                )
-            ],
-        )
+    electricity_meter = _make_electricity_meter(
+        valid_from=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        valid_to=datetime(2027, 5, 24, tzinfo=timezone.utc),
+        prior_agreements=[
+            Agreement(
+                tariff_code=f"E-1R-{PRODUCT_CODE}-{REGION}",
+                valid_from=datetime(2025, 5, 24, tzinfo=timezone.utc),
+                valid_to=datetime(2026, 5, 24, tzinfo=timezone.utc),
+            )
+        ],
     )
+    retriever = CostForecastRetriever(_source(mariadb_client, [electricity_meter]))
     retriever.refresh(as_of=datetime(2026, 7, 7, tzinfo=timezone.utc))
 
     with mariadb_client.session_read_scope() as session:
@@ -715,6 +724,52 @@ def test_current_agreement_with_a_bounded_valid_to_still_matches(
 
     assert len(stored) == 1
     assert stored[0].actual_cost_to_date == Decimal("0.88")
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "valid_from, valid_to, should_match",
+    [
+        pytest.param(
+            datetime(2026, 7, 7, tzinfo=timezone.utc),
+            datetime(2027, 7, 7, tzinfo=timezone.utc),
+            True,
+            id="valid_from_boundary_is_inclusive",
+        ),
+        pytest.param(
+            datetime(2022, 1, 1, tzinfo=timezone.utc),
+            datetime(2026, 7, 7, tzinfo=timezone.utc),
+            False,
+            id="valid_to_boundary_is_exclusive",
+        ),
+    ],
+)
+def test_current_agreement_half_open_interval_boundaries(
+    mariadb_client: MariaDBClient,
+    valid_from: datetime,
+    valid_to: datetime,
+    should_match: bool,
+) -> None:
+    # valid_from is inclusive, valid_to is exclusive -- otherwise a renewal's
+    # first instant would match both the expiring and incoming agreement.
+    _mock_billing_period("2026-07-06", "2026-08-06")
+    as_of = datetime(2026, 7, 7, tzinfo=timezone.utc)
+
+    with mariadb_client.session_write_scope() as s:
+        _seed_fixed_tariff_agreement_and_rate(s)
+
+    electricity_meter = _make_electricity_meter(
+        valid_from=valid_from, valid_to=valid_to
+    )
+    retriever = CostForecastRetriever(_source(mariadb_client, [electricity_meter]))
+
+    if should_match:
+        retriever.refresh(as_of=as_of)
+        with mariadb_client.session_read_scope() as session:
+            assert session.query(model.cost_forecast).count() == 1
+    else:
+        with pytest.raises(RuntimeError, match="[Nn]o current .*agreement"):
+            retriever.refresh(as_of=as_of)
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- `CostForecastRetriever._current_electricity_agreement()` wrongly assumed the "current" electricity agreement is identifiable by `valid_to IS NULL`. Real Agile contracts renew as fixed one-year terms, so Octopus's API never returns `valid_to: null` for them, even for the currently-active agreement — confirmed live on a real Agile-tariff account, where `cost_forecast.refresh()` failed (non-fatally, but permanently) every time it ran.
- Fixes this by selecting "current" via range containment (`valid_from <= as_of AND (valid_to IS NULL OR as_of < valid_to)`), mirroring the convention already used in `app/data/mysql/client.py`'s `read_current_product_rate` and its consumption-to-agreement join.
- Adds regression coverage: a two-agreement fixture (lapsed + bounded current) proving range-selection, plus a parametrized test for the half-open interval's inclusive `valid_from` / exclusive `valid_to` boundaries.

Closes #425.

## Test plan
- [x] `uv run pytest tests/test_cost_forecast_retriever.py` — 17 passed
- [x] `uv run pytest` (full suite) — 160 passed
- [x] `pre-commit run --all-files` — clean
- [x] Two-axis code review (Standards + Spec), 3 iterations, no blocking findings on either axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)