### PR TITLE
Reduce DNS-resolution failure exposure: persistent session reuse + fallback resolver

### DIFF
--- a/.agent-docs/issues/chore-dns-resilience-and-session-reuse.md
+++ b/.agent-docs/issues/chore-dns-resilience-and-session-reuse.md
@@ -1,5 +1,7 @@
 # Issues: chore-dns-resilience-and-session-reuse
 
+> Work complete — PR ready to merge.
+
 ## Persistent HTTP session in OctopusTransport
 
 **GitHub issue**: #427
@@ -23,14 +25,14 @@ alone.
 
 ### Acceptance criteria
 
-- [ ] `OctopusTransport.__init__` creates `self._session = requests.Session()`
+- [x] `OctopusTransport.__init__` creates `self._session = requests.Session()`
       and sets auth on it once, instead of passing `auth=(...)` per call.
-- [ ] `get()` calls `self._session.get(...)` instead of the module-level
+- [x] `get()` calls `self._session.get(...)` instead of the module-level
       `requests.get(...)`.
-- [ ] All existing tests in `tests/test_octopus_transport.py` pass unmodified.
-- [ ] New test proves the same `Session` instance is reused across multiple
+- [x] All existing tests in `tests/test_octopus_transport.py` pass unmodified.
+- [x] New test proves the same `Session` instance is reused across multiple
       `get()` calls.
-- [ ] New regression test: a connection-level failure on the first attempt
+- [x] New regression test: a connection-level failure on the first attempt
       followed by a successful response on retry still succeeds end-to-end,
       proving session reuse doesn't break the existing `@retry()` path.
 
@@ -53,9 +55,9 @@ service only, so a brief unresponsive spell from the LAN's primary resolver
 
 ### Acceptance criteria
 
-- [ ] `energy-monitor` service in `docker-compose.yml` has
+- [x] `energy-monitor` service in `docker-compose.yml` has
       `dns: [192.168.0.50, 1.1.1.1]`, primary listed first.
-- [ ] `mariadb` service is unchanged (no `dns:` key added).
-- [ ] `docker compose config` validates the file cleanly.
+- [x] `mariadb` service is unchanged (no `dns:` key added).
+- [x] `docker compose config` validates the file cleanly.
 
 ---

--- a/.agent-docs/issues/chore-dns-resilience-and-session-reuse.md
+++ b/.agent-docs/issues/chore-dns-resilience-and-session-reuse.md
@@ -1,0 +1,61 @@
+# Issues: chore-dns-resilience-and-session-reuse
+
+## Persistent HTTP session in OctopusTransport
+
+**GitHub issue**: #427
+
+**Blocked by**: None
+
+**User stories**: 1, 3
+
+### What to build
+
+`OctopusTransport` creates a single `requests.Session` in `__init__` (with
+auth set on it once) instead of calling the bare, module-level
+`requests.get(...)` on every `get()` call. This means a burst of hundreds of
+sequential paginated requests to the same host during a historical backfill
+resolves DNS once and reuses a keep-alive connection, instead of paying a
+fresh DNS lookup + TLS handshake per request. Everything else about `get()`
+(the `@retry()` decorator, `REQUEST_TIMEOUT_SECONDS`, `raise_for_http_error`
+handling) stays as-is. `KrakenTransport` and `AgilePredictClient` keep their
+existing bare-`requests` pattern — same shape, much lower call volume, left
+alone.
+
+### Acceptance criteria
+
+- [ ] `OctopusTransport.__init__` creates `self._session = requests.Session()`
+      and sets auth on it once, instead of passing `auth=(...)` per call.
+- [ ] `get()` calls `self._session.get(...)` instead of the module-level
+      `requests.get(...)`.
+- [ ] All existing tests in `tests/test_octopus_transport.py` pass unmodified.
+- [ ] New test proves the same `Session` instance is reused across multiple
+      `get()` calls.
+- [ ] New regression test: a connection-level failure on the first attempt
+      followed by a successful response on retry still succeeds end-to-end,
+      proving session reuse doesn't break the existing `@retry()` path.
+
+---
+
+## Fallback DNS resolver for the energy-monitor container
+
+**GitHub issue**: #428
+
+**Blocked by**: None
+
+**User stories**: 2
+
+### What to build
+
+Add a fallback DNS resolver to `docker-compose.yml`'s `energy-monitor`
+service only, so a brief unresponsive spell from the LAN's primary resolver
+(`192.168.0.50`, the pi-hole box) doesn't cause a resolution failure outright.
+`mariadb` makes no external calls and doesn't need it.
+
+### Acceptance criteria
+
+- [ ] `energy-monitor` service in `docker-compose.yml` has
+      `dns: [192.168.0.50, 1.1.1.1]`, primary listed first.
+- [ ] `mariadb` service is unchanged (no `dns:` key added).
+- [ ] `docker compose config` validates the file cleanly.
+
+---

--- a/.agent-docs/specs/chore-dns-resilience-and-session-reuse.md
+++ b/.agent-docs/specs/chore-dns-resilience-and-session-reuse.md
@@ -146,9 +146,9 @@ same live-monitoring window. Agreed acceptance bar: *meaningfully reduce* the
 frequency of DNS-caused failures, not eliminate them entirely; must be
 testable without a live Pi redeploy.
 
-This document intentionally lives on the `bugfix/cost-forecast-current-
-agreement-range` branch alongside the unrelated agreement-bug fix, rather
-than its own branch — an explicit, deliberate choice this session because two
-agents were working in parallel against one shared working directory. Pick a
-proper dedicated branch (e.g. `chore/dns-resilience-and-session-reuse`) when
-actually picking this up for implementation.
+This document was originally drafted on the `bugfix/cost-forecast-current-
+agreement-range` branch alongside the unrelated agreement-bug fix — an
+explicit, deliberate choice at the time because two agents were working in
+parallel against one shared working directory. Now moved to its own
+dedicated `chore/dns-resilience-and-session-reuse` branch (created from
+`main` after PR #426 merged) for implementation.

--- a/app/data/octopus/transport.py
+++ b/app/data/octopus/transport.py
@@ -15,6 +15,10 @@ class OctopusTransport:
     base_url: str = "https://api.octopus.energy/v1/"
 
     def __init__(self, settings: OctopusAPISettings) -> None:
+        # Shared across concurrent background job threads (see
+        # _run_with_backoff_in_background in main.py) -- safe without extra
+        # locking since urllib3's connection pool is internally locked, and
+        # auth is set once here and never mutated per-call.
         self._session = requests.Session()
         self._session.auth = (settings.api_key, "")
 

--- a/app/data/octopus/transport.py
+++ b/app/data/octopus/transport.py
@@ -15,7 +15,8 @@ class OctopusTransport:
     base_url: str = "https://api.octopus.energy/v1/"
 
     def __init__(self, settings: OctopusAPISettings) -> None:
-        self._api_key = settings.api_key
+        self._session = requests.Session()
+        self._session.auth = (settings.api_key, "")
 
     @retry()
     def get(
@@ -27,9 +28,8 @@ class OctopusTransport:
     ) -> T:
         response: Optional[requests.Response] = None
         try:
-            response = requests.get(
+            response = self._session.get(
                 url=url,
-                auth=(self._api_key, ""),
                 params=params,
                 timeout=REQUEST_TIMEOUT_SECONDS,
             )

--- a/app/data/octopus/transport.py
+++ b/app/data/octopus/transport.py
@@ -16,9 +16,12 @@ class OctopusTransport:
 
     def __init__(self, settings: OctopusAPISettings) -> None:
         # Shared across concurrent background job threads (see
-        # _run_with_backoff_in_background in main.py) -- safe without extra
-        # locking since urllib3's connection pool is internally locked, and
-        # auth is set once here and never mutated per-call.
+        # _run_with_backoff_in_background in main.py) -- one Session for
+        # connection reuse, relying on urllib3's own internally-locked
+        # connection pool for concurrent GETs. requests.Session doesn't
+        # document a blanket thread-safety guarantee, so session state
+        # (auth, headers, cookies) must never be mutated after construction;
+        # auth is set once here, immediately below, and nowhere else.
         self._session = requests.Session()
         self._session.auth = (settings.api_key, "")
 

--- a/app/main.py
+++ b/app/main.py
@@ -31,8 +31,8 @@ PRICING_REFRESH_JOB = "pricing_refresh"
 WEEKLY_CONSUMPTION_SUMMARY_JOB = "update_consumption_summary"
 YEARLY_COMPARISON_BACKFILL_JOB = "yearly_comparison_backfill"
 COST_FORECAST_REFRESH_JOB = "cost_forecast_refresh"
-WEEKLY_JOB_TIME = "03:00"  # Monday, for weekly-cadence jobs
-DAILY_JOB_TIME = "04:00"  # for daily-cadence jobs
+DAILY_JOB_TIME = "04:00"  # shared by every daily/weekly-cadence job, so
+# none of them land in watchtower's 03:00 update window (see docker-compose.yml)
 
 
 def startup(
@@ -160,7 +160,7 @@ def register_consumption_summary_job(
 ) -> Job:
     return _schedule_refresh_job(
         scheduler,
-        lambda s: s.every().monday.at(WEEKLY_JOB_TIME),
+        lambda s: s.every().monday.at(DAILY_JOB_TIME),
         WEEKLY_CONSUMPTION_SUMMARY_JOB,
         consumption_summary.refresh,
         mariadb,

--- a/app/main.py
+++ b/app/main.py
@@ -32,7 +32,9 @@ WEEKLY_CONSUMPTION_SUMMARY_JOB = "update_consumption_summary"
 YEARLY_COMPARISON_BACKFILL_JOB = "yearly_comparison_backfill"
 COST_FORECAST_REFRESH_JOB = "cost_forecast_refresh"
 DAILY_JOB_TIME = "04:00"  # shared by every daily/weekly-cadence job, so
-# none of them land in watchtower's 03:00 update window (see docker-compose.yml)
+# none of them land in watchtower's 03:00 update window -- that schedule is
+# configured on the Pi host (pi-desktop's compose stack), not in this repo's
+# docker-compose.yml, which only enables watchtower via container labels.
 
 
 def startup(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - /mnt/media/pi-media/monitoring/log/energy-monitor:/log
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    dns:
+      - 192.168.0.50
+      - 1.1.1.1
     restart: unless-stopped
     depends_on:
       mariadb:

--- a/tests/test_octopus_transport.py
+++ b/tests/test_octopus_transport.py
@@ -1,3 +1,5 @@
+from typing import Any, List
+
 import pytest
 import requests
 import responses
@@ -23,6 +25,36 @@ def test_get_returns_the_validated_response_model() -> None:
     result = transport.get(ENDPOINT, _WidgetResponse)
 
     assert result.name == "gadget"
+
+
+@responses.activate
+def test_get_reuses_the_same_session_across_multiple_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A historical backfill makes hundreds of sequential paginated requests
+    # to the same host -- each call should resolve DNS and open a connection
+    # once, not per request, so a burst is served by one requests.Session
+    # rather than a fresh one every time.
+    responses.add(responses.GET, ENDPOINT, json={"name": "gadget"}, status=200)
+    responses.add(responses.GET, ENDPOINT, json={"name": "gadget"}, status=200)
+    transport = OctopusTransport(
+        OctopusAPISettings(account_number="A-1234ABCD", api_key="sk_live_test")
+    )
+
+    serving_sessions: List[requests.Session] = []
+    original_get = requests.Session.get
+
+    def spy_get(self: requests.Session, *args: Any, **kwargs: Any) -> requests.Response:
+        serving_sessions.append(self)
+        return original_get(self, *args, **kwargs)
+
+    monkeypatch.setattr(requests.Session, "get", spy_get)
+
+    transport.get(ENDPOINT, _WidgetResponse)
+    transport.get(ENDPOINT, _WidgetResponse)
+
+    assert len(serving_sessions) == 2
+    assert serving_sessions[0] is serving_sessions[1]
 
 
 @responses.activate
@@ -75,6 +107,29 @@ def test_get_raises_a_descriptive_runtime_error_on_connection_failure(
 
     with pytest.raises(RuntimeError, match="fetch widgets.*connection timed out"):
         transport.get(ENDPOINT, _WidgetResponse, description="fetch widgets")
+
+
+@responses.activate
+def test_get_succeeds_after_a_transient_connection_failure_via_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression test: a reused, potentially stale pooled connection must not
+    # break the existing @retry() path -- urllib3's connection pool evicts a
+    # dead pooled connection and opens a fresh one on the retried call.
+    monkeypatch.setattr("common.decorator.time.sleep", lambda seconds: None)
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        body=requests.exceptions.ConnectionError("connection reset"),
+    )
+    responses.add(responses.GET, ENDPOINT, json={"name": "gadget"}, status=200)
+    transport = OctopusTransport(
+        OctopusAPISettings(account_number="A-1234ABCD", api_key="sk_live_test")
+    )
+
+    result = transport.get(ENDPOINT, _WidgetResponse)
+
+    assert result.name == "gadget"
 
 
 @responses.activate

--- a/tests/test_refresh_scheduling.py
+++ b/tests/test_refresh_scheduling.py
@@ -167,7 +167,7 @@ def test_run_initial_pricing_sync_does_not_propagate_a_startup_failure() -> None
     run_initial_pricing_sync(pricing)
 
 
-def test_consumption_summary_job_is_registered_for_monday_at_0300(
+def test_consumption_summary_job_is_registered_for_monday_at_0400(
     mariadb_client: MariaDBClient,
 ) -> None:
     scheduler = Scheduler()
@@ -178,7 +178,7 @@ def test_consumption_summary_job_is_registered_for_monday_at_0300(
 
     assert job.unit == "weeks"
     assert job.start_day == "monday"
-    assert str(job.at_time) == "03:00:00"
+    assert str(job.at_time) == "04:00:00"
 
 
 def test_a_successful_consumption_summary_run_is_recorded_as_a_successful_job_run(


### PR DESCRIPTION
## Summary
- `OctopusTransport` now creates a single `requests.Session` once in `__init__` instead of calling module-level `requests.get(...)` per call, so a historical backfill's burst of hundreds of sequential requests resolves DNS and opens a connection once, not per request.
- `docker-compose.yml`'s `energy-monitor` service gets a fallback DNS resolver (`1.1.1.1`, after the primary `192.168.0.50`) so a brief unresponsive spell from the LAN's primary resolver doesn't cause an outright failure.
- Both changes are independent, config/transport-level reliability hardening -- found live during this repo's first real Pi deployment monitoring window (intermittent `NameResolutionError`, self-healed by the existing `@retry()` but frequent enough during a backfill to be worth fixing directly).

Closes #427. Closes #428.

Also includes one unrelated commit (`4c115a1`, "Align weekly job to run at 04:00") from separate work done concurrently on this same branch/working directory -- not part of this PR's spec, called out here for reviewer clarity.

## Test plan
- [x] `uv run pytest tests/test_octopus_transport.py` -- 7 passed (2 new: session-reuse identity, retry-survives-a-transient-connection-failure)
- [x] `uv run pytest` (full suite) -- 162 passed
- [x] `docker compose config` -- validates cleanly, `dns:` present on `energy-monitor` only
- [x] `pre-commit run --all-files` -- clean
- [x] Two-axis code review (Standards + Spec), 3 iterations, no blocking findings on either axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)