### PR TITLE
Skip rate fetches for zero-width agreements

### DIFF
--- a/.agent-docs/issues/bugfix-zero-width-agreement-rate-fetch.md
+++ b/.agent-docs/issues/bugfix-zero-width-agreement-rate-fetch.md
@@ -1,0 +1,34 @@
+# Issues: bugfix-zero-width-agreement-rate-fetch
+
+## Skip rate fetches for zero/negative-width agreements
+
+**GitHub issue**: #431
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3
+
+### What to build
+
+In `PricingRetriever._sync_own_product_rates()`, add a guard before the rate-fetch
+call that skips any agreement whose `valid_from` is on or after its `valid_to` (when
+`valid_to` is not `None`), for both electricity and gas agreements. Log the skip at
+debug level instead of letting the call reach Octopus's API and fail. The guard is
+local to `_sync_own_product_rates()` — it does not touch `_meter_agreement_pairs()` or
+`_sync_comparison_rates()`, which must keep behaving exactly as before. The existing
+`try/except` around the fetch call remains, as a safety net for other failure modes.
+
+### Acceptance criteria
+
+- [ ] An electricity agreement with `valid_from == valid_to` never reaches
+      `fetch_electricity_rates`, and a debug-level log line is emitted for it.
+- [ ] A gas agreement with `valid_from == valid_to` never reaches `fetch_gas_rates`,
+      and a debug-level log line is emitted for it.
+- [ ] `_sync_comparison_rates()`'s `own_product_codes` exclusion set is unaffected —
+      a skipped agreement's product code still excludes it from comparison-rate
+      syncing.
+- [ ] Existing agreements with valid (non-degenerate) ranges are unaffected — rates
+      are still fetched and persisted for them exactly as before.
+- [ ] Full test suite and pre-commit hooks pass.
+
+---

--- a/.agent-docs/issues/bugfix-zero-width-agreement-rate-fetch.md
+++ b/.agent-docs/issues/bugfix-zero-width-agreement-rate-fetch.md
@@ -1,5 +1,7 @@
 # Issues: bugfix-zero-width-agreement-rate-fetch
 
+> Work complete — PR ready to merge.
+
 ## Skip rate fetches for zero/negative-width agreements
 
 **GitHub issue**: #431
@@ -20,15 +22,15 @@ local to `_sync_own_product_rates()` — it does not touch `_meter_agreement_pai
 
 ### Acceptance criteria
 
-- [ ] An electricity agreement with `valid_from == valid_to` never reaches
+- [x] An electricity agreement with `valid_from == valid_to` never reaches
       `fetch_electricity_rates`, and a debug-level log line is emitted for it.
-- [ ] A gas agreement with `valid_from == valid_to` never reaches `fetch_gas_rates`,
+- [x] A gas agreement with `valid_from == valid_to` never reaches `fetch_gas_rates`,
       and a debug-level log line is emitted for it.
-- [ ] `_sync_comparison_rates()`'s `own_product_codes` exclusion set is unaffected —
+- [x] `_sync_comparison_rates()`'s `own_product_codes` exclusion set is unaffected —
       a skipped agreement's product code still excludes it from comparison-rate
       syncing.
-- [ ] Existing agreements with valid (non-degenerate) ranges are unaffected — rates
+- [x] Existing agreements with valid (non-degenerate) ranges are unaffected — rates
       are still fetched and persisted for them exactly as before.
-- [ ] Full test suite and pre-commit hooks pass.
+- [x] Full test suite and pre-commit hooks pass.
 
 ---

--- a/.agent-docs/specs/bugfix-zero-width-agreement-rate-fetch.md
+++ b/.agent-docs/specs/bugfix-zero-width-agreement-rate-fetch.md
@@ -1,0 +1,102 @@
+# Skip rate fetches for zero-width agreements
+
+## Problem Statement
+
+`PricingRetriever._sync_own_product_rates()` fetches rates for every agreement on
+every meter, once per hourly `pricing_refresh` run. At least one real account has a
+historical agreement whose `valid_from` and `valid_to` are identical
+(`VAR-22-11-01`/`E-1R-VAR-22-11-01-C`, both `2025-05-23T23:00:00Z`). Forwarding that
+zero-width range straight to Octopus's rates endpoint as `period_from`/`period_to`
+always gets a 400 response, because the endpoint rejects identical bounds.
+
+This is already caught by the existing `try/except` around the fetch call, so there is
+no data loss and `pricing_refresh` still completes successfully every hour — but the
+account pays for 3 wasted, automatically-retried HTTP calls every hour, forever, for
+an agreement that can never produce a valid rate window. Nothing will change about
+Octopus's historical data to fix this on its own.
+
+## Solution
+
+Recognise the zero/negative-width condition before making the network call, for both
+electricity and gas agreements, and skip the fetch entirely rather than relying on the
+exception handler to clean up after a guaranteed failure. The skip is logged at debug
+level — this is an expected, permanent condition for this agreement, not something
+that needs operator attention, but it stays traceable for anyone investigating why an
+agreement never gets rates.
+
+## User Stories
+
+1. As the pricing pipeline, I want to recognise agreements whose valid range can never
+   produce a rate window, so that I stop making calls to Octopus's API that are
+   guaranteed to fail.
+2. As an operator reading logs, I want a clear, low-noise trace of why a specific
+   agreement's rates are never synced, so that I can distinguish "expected, permanent
+   skip" from "transient failure worth investigating."
+3. As a future maintainer, I want the existing `try/except` around the fetch call to
+   keep catching genuine failures (network errors, other 400s), so that this fix
+   narrows the failure surface without removing the safety net.
+
+## Implementation Decisions
+
+- **Module**: `app/data/pricing.py`, `PricingRetriever._sync_own_product_rates()`.
+- Add a guard inside the existing loop, immediately before the `fetch_rates(...)`
+  call: if `agreement.valid_from >= agreement.valid_to` (only meaningful when
+  `valid_to` is not `None`), log at debug level and `continue` — do not call
+  `fetch_rates`, do not call `persist_rate`.
+- The condition is `>=`, not just `==`, so it also covers a theoretical inverted range
+  (`valid_from` after `valid_to`), not only the exact-equality case seen in production.
+- The guard applies to both electricity and gas agreements. `_sync_own_product_rates`
+  already branches on `meter.energy` to pick `fetch_electricity_rates` vs.
+  `fetch_gas_rates` for the same loop body, so placing the guard before that branch
+  covers both meter types with no extra code.
+- **Do not** move or duplicate this guard into `_meter_agreement_pairs()`. That
+  iterator is also consumed by `_sync_comparison_rates()` to build
+  `own_product_codes`, the set used to exclude the account's own products from
+  comparison-rate syncing (`app/data/pricing.py:109-112`). If the zero-width
+  agreement were filtered out at the shared iterator, its product code would stop
+  being excluded there too, and the dead product would incorrectly get synced as a
+  comparison rate instead — a different waste than the one being fixed. The guard
+  must be local to `_sync_own_product_rates()`.
+- The existing `try/except Exception` around the fetch call in
+  `_sync_own_product_rates()` stays as-is — it remains the safety net for genuine,
+  non-permanent failures (network errors, other unexpected 400s). This fix only
+  removes the *known, permanent* zero-width case from ever reaching it.
+
+## Testing Decisions
+
+- Test through the existing top seam: `PricingRetriever.refresh()`, using the
+  `_RealPricingSource` adapter and fixture-building helpers already established in
+  `tests/test_pricing_retrieval.py` (genuine `OctopusEnergyAPIClient` and
+  `MariaDBClient` underneath, HTTP mocked via `responses`).
+- New regression test: build an electricity meter whose agreement has
+  `valid_from == valid_to`, run `refresh()`, and assert via `responses` that the
+  electricity rates endpoint was never called for that agreement (no matching
+  registered call was made) and that no `product_rate` row was persisted for it.
+- Add an equivalent case for a gas agreement with `valid_from == valid_to`, asserting
+  the gas rates endpoint is never called, to cover the "applies to both energy types"
+  decision.
+- Assert the debug-level log message is emitted (via `caplog`), to lock in the chosen
+  log level as a regression guard against it silently reverting to `warning` or
+  disappearing entirely.
+- Existing fixtures in this file all use `valid_to=None` for the "current" agreement,
+  per the prior finding (see `[[octopus-monitoring-pricing-pipeline]]` memory) that
+  fixtures coincidentally simplifying away real-world date-range shapes have hidden
+  bugs before. The new fixture deliberately uses a non-`None`, degenerate `valid_to`
+  to avoid repeating that pattern.
+
+## Out of Scope
+
+- Changing `_sync_comparison_rates()` or `_meter_agreement_pairs()` — both are
+  unaffected by this fix, and the spec explicitly does not want them touched.
+- Backfilling or correcting the historical agreement data itself (Octopus's data is
+  authoritative and out of this codebase's control) — the fix only stops the pipeline
+  from repeatedly trying to fetch rates for a range that can never be valid.
+- Broader validation of `Agreement` shape elsewhere in the codebase (e.g. at
+  ingestion/persistence time) — this spec is scoped to the one call site that makes
+  the network call.
+
+## Further Notes
+
+Originally identified and deferred in a prior session's DNS-resilience work
+(`chore/dns-resilience-and-session-reuse`), noted there as out-of-scope for that
+branch. No GitHub issue existed for it before this spec.

--- a/app/data/octopus/model.py
+++ b/app/data/octopus/model.py
@@ -153,7 +153,7 @@ class Agreement:
         return cls(tariff_code, valid_from, valid_to)
 
     @property
-    def has_no_possible_rate_window(self) -> bool:
+    def has_zero_or_negative_width(self) -> bool:
         return self.valid_to is not None and self.valid_from >= self.valid_to
 
 

--- a/app/data/octopus/model.py
+++ b/app/data/octopus/model.py
@@ -152,6 +152,10 @@ class Agreement:
         valid_to = None if not info.valid_to else datetime.fromisoformat(info.valid_to)
         return cls(tariff_code, valid_from, valid_to)
 
+    @property
+    def has_no_possible_rate_window(self) -> bool:
+        return self.valid_to is not None and self.valid_from >= self.valid_to
+
 
 class Meter(ABC):
     energy: Energy

--- a/app/data/pricing.py
+++ b/app/data/pricing.py
@@ -84,10 +84,7 @@ class PricingRetriever:
 
     def _sync_own_product_rates(self) -> None:
         for meter, agreement in self._meter_agreement_pairs():
-            if (
-                agreement.valid_to is not None
-                and agreement.valid_from >= agreement.valid_to
-            ):
+            if agreement.has_no_possible_rate_window:
                 logger.debug(
                     f"Agreement {agreement.product_code}/{agreement.tariff_code} "
                     f"has a zero or negative-width valid range "

--- a/app/data/pricing.py
+++ b/app/data/pricing.py
@@ -84,6 +84,17 @@ class PricingRetriever:
 
     def _sync_own_product_rates(self) -> None:
         for meter, agreement in self._meter_agreement_pairs():
+            if (
+                agreement.valid_to is not None
+                and agreement.valid_from >= agreement.valid_to
+            ):
+                logger.debug(
+                    f"Agreement {agreement.product_code}/{agreement.tariff_code} "
+                    f"has a zero or negative-width valid range "
+                    f"({agreement.valid_from} to {agreement.valid_to}) — no rate "
+                    "window is possible, skipping."
+                )
+                continue
             fetch_rates = (
                 self._client.fetch_electricity_rates
                 if meter.energy == Energy.electricity

--- a/app/data/pricing.py
+++ b/app/data/pricing.py
@@ -84,7 +84,7 @@ class PricingRetriever:
 
     def _sync_own_product_rates(self) -> None:
         for meter, agreement in self._meter_agreement_pairs():
-            if agreement.has_no_possible_rate_window:
+            if agreement.has_zero_or_negative_width:
                 logger.debug(
                     f"Agreement {agreement.product_code}/{agreement.tariff_code} "
                     f"has a zero or negative-width valid range "

--- a/tests/test_pricing_retrieval.py
+++ b/tests/test_pricing_retrieval.py
@@ -690,7 +690,9 @@ def test_refresh_skips_the_rate_fetch_for_a_zero_width_electricity_agreement(
         stored = session.query(model.product_rate).all()
     assert stored == []
     assert any(
-        record.levelno == logging.DEBUG and "E-1R-VAR-22-11-01-C" in record.message
+        record.levelno == logging.DEBUG
+        and "VAR-22-11-01/E-1R-VAR-22-11-01-C" in record.message
+        and "zero or negative-width" in record.message
         for record in caplog.records
     )
 
@@ -722,7 +724,9 @@ def test_refresh_skips_the_rate_fetch_for_a_zero_width_gas_agreement(
         stored = session.query(model.product_rate).all()
     assert stored == []
     assert any(
-        record.levelno == logging.DEBUG and "G-1R-VAR-22-11-01-C" in record.message
+        record.levelno == logging.DEBUG
+        and "VAR-22-11-01/G-1R-VAR-22-11-01-C" in record.message
+        and "zero or negative-width" in record.message
         for record in caplog.records
     )
 

--- a/tests/test_pricing_retrieval.py
+++ b/tests/test_pricing_retrieval.py
@@ -93,6 +93,20 @@ def _make_electricity_meter() -> Electricity:
     )
 
 
+def _make_electricity_meter_with_zero_width_agreement() -> Electricity:
+    return Electricity(
+        mpan="1234567890123",
+        serial_number="00A1234567",
+        agreements=[
+            Agreement(
+                tariff_code="E-1R-VAR-22-11-01-C",
+                valid_from=datetime(2025, 5, 23, 23, tzinfo=timezone.utc),
+                valid_to=datetime(2025, 5, 23, 23, tzinfo=timezone.utc),
+            )
+        ],
+    )
+
+
 def _make_gas_meter() -> Gas:
     return Gas(
         mprn="9876543210987",
@@ -102,6 +116,20 @@ def _make_gas_meter() -> Gas:
                 tariff_code="G-1R-VAR-22-11-01-A",
                 valid_from=datetime(2022, 11, 1, tzinfo=timezone.utc),
                 valid_to=None,
+            )
+        ],
+    )
+
+
+def _make_gas_meter_with_zero_width_agreement() -> Gas:
+    return Gas(
+        mprn="9876543210987",
+        serial_number="00G7654321",
+        agreements=[
+            Agreement(
+                tariff_code="G-1R-VAR-22-11-01-C",
+                valid_from=datetime(2025, 5, 23, 23, tzinfo=timezone.utc),
+                valid_to=datetime(2025, 5, 23, 23, tzinfo=timezone.utc),
             )
         ],
     )
@@ -633,3 +661,117 @@ def test_refresh_does_not_refetch_the_account_s_own_product_during_the_compariso
 
     assert len(stored) == 1
     assert stored[0].unit_rate == Decimal("24.53")
+
+
+@responses.activate
+def test_refresh_skips_the_rate_fetch_for_a_zero_width_electricity_agreement(
+    mariadb_client: MariaDBClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses.add(
+        responses.GET, PRODUCTS_ENDPOINT, json={"results": [], "next": None}, status=200
+    )
+    _mock_electricity_rate_endpoints(
+        product_code="VAR-22-11-01", tariff_code="E-1R-VAR-22-11-01-C"
+    )
+    electricity_meter = _make_electricity_meter_with_zero_width_agreement()
+    source = _make_source(mariadb_client, [electricity_meter])
+
+    with caplog.at_level(logging.DEBUG, logger="octopus-monitor"):
+        PricingRetriever(source).refresh()
+
+    rate_calls = [
+        call
+        for call in responses.calls
+        if "electricity-tariffs/E-1R-VAR-22-11-01-C" in call.request.url
+    ]
+    assert rate_calls == []
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(model.product_rate).all()
+    assert stored == []
+    assert any(
+        record.levelno == logging.DEBUG and "E-1R-VAR-22-11-01-C" in record.message
+        for record in caplog.records
+    )
+
+
+@responses.activate
+def test_refresh_skips_the_rate_fetch_for_a_zero_width_gas_agreement(
+    mariadb_client: MariaDBClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses.add(
+        responses.GET, PRODUCTS_ENDPOINT, json={"results": [], "next": None}, status=200
+    )
+    _mock_gas_rate_endpoints(
+        product_code="VAR-22-11-01", tariff_code="G-1R-VAR-22-11-01-C"
+    )
+    gas_meter = _make_gas_meter_with_zero_width_agreement()
+    source = _make_source(mariadb_client, [gas_meter])
+
+    with caplog.at_level(logging.DEBUG, logger="octopus-monitor"):
+        PricingRetriever(source).refresh()
+
+    rate_calls = [
+        call
+        for call in responses.calls
+        if "gas-tariffs/G-1R-VAR-22-11-01-C" in call.request.url
+    ]
+    assert rate_calls == []
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(model.product_rate).all()
+    assert stored == []
+    assert any(
+        record.levelno == logging.DEBUG and "G-1R-VAR-22-11-01-C" in record.message
+        for record in caplog.records
+    )
+
+
+@responses.activate
+def test_refresh_still_excludes_a_zero_width_agreement_s_product_from_comparison_sync(
+    mariadb_client: MariaDBClient,
+) -> None:
+    """A zero-width agreement's own rate fetch is skipped, but its product
+    code must still count as "owned" so the comparison pass doesn't treat it
+    as a general-catalogue product and fetch rates for it under an
+    arbitrarily-picked billing method."""
+    responses.add(
+        responses.GET,
+        PRODUCTS_ENDPOINT,
+        json={
+            "results": [
+                {
+                    "code": "VAR-22-11-01",
+                    "display_name": "Flexible Octopus",
+                    "direction": "IMPORT",
+                }
+            ],
+            "next": None,
+        },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        PRODUCTS_ENDPOINT + "VAR-22-11-01/",
+        json={
+            "single_register_electricity_tariffs": {
+                "H": {"direct_debit_monthly": {"code": "E-1R-VAR-22-11-01-H"}}
+            }
+        },
+        status=200,
+    )
+    electricity_meter = _make_electricity_meter_with_zero_width_agreement()
+    source = _make_source(mariadb_client, [electricity_meter])
+
+    PricingRetriever(source).refresh()
+
+    product_detail_calls = [
+        call
+        for call in responses.calls
+        if call.request.url.startswith(PRODUCTS_ENDPOINT + "VAR-22-11-01/")
+    ]
+    assert len(product_detail_calls) == 1
+
+    with mariadb_client.session_read_scope() as session:
+        stored = session.query(model.product_rate).all()
+    assert stored == []


### PR DESCRIPTION
## Summary
- `PricingRetriever._sync_own_product_rates()` now skips agreements whose `valid_from >= valid_to` (when `valid_to` is set) before calling Octopus's rate-fetch endpoint, instead of relying on the existing `try/except` to clean up after a guaranteed 400.
- New `Agreement.has_zero_or_negative_width` property carries the check on the domain object itself.
- Skips are logged at `debug` level (expected, permanent condition — not an operator-actionable warning).
- Applies to both electricity and gas agreements via one shared check.
- `_meter_agreement_pairs()` and `_sync_comparison_rates()`'s `own_product_codes` exclusion set are deliberately untouched — a skipped agreement's product code still counts as "owned" so it isn't incorrectly re-synced as a comparison product.

Closes #431.

## Test plan
- [x] New regression tests: zero-width electricity agreement, zero-width gas agreement, comparison-sync exclusion unaffected.
- [x] Full test suite passes (165 tests).
- [x] Pre-commit hooks pass (mypy, black, isort, ruff, bandit, pylint, etc.).
- [x] Two independent two-axis (Standards + Spec) code review passes, both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)