### PR TITLE
chore: gitignore .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ energy-monitor-temp
 # worktrees created via an explicit sibling path, as this repo's convention
 # does, live outside the repo tree and need no ignore rule)
 /.claude/worktrees/
+.claude


### PR DESCRIPTION
## Summary

- Adds `.claude` to `.gitignore` so Claude Code session/worktree state never gets committed.

This was already applied locally on `main` but never went through a PR (direct pushes to `main` are protected). Splitting it out here to close the gap between local and `origin/main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)